### PR TITLE
Make plugin work in the latest nigthly version of NINA

### DIFF
--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -232,9 +232,14 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         public int GainMax {
             get {
                 if (_camera != null) {
-                    PropertyInfo gainInfo = _camera.GetPropertyInfo(PROPID_ISOS);
+                    try {
+                        PropertyInfo gainInfo = _camera.GetPropertyInfo(PROPID_ISOS);
 
-                    return (int)gainInfo.Options().Last().Value;
+                        return (int)gainInfo.Options().Last().Value;
+                    } catch (Exception ex) {
+                        Logger.Error("Problem getting gain min", ex);
+                        return -1;
+                    }
                 } else {
                     return 0;
                 }
@@ -244,9 +249,14 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         public int GainMin {
             get {
                 if (_camera != null) {
-                    PropertyInfo gainInfo = _camera.GetPropertyInfo(PROPID_ISOS);
+                    try {
+                        PropertyInfo gainInfo = _camera.GetPropertyInfo(PROPID_ISOS);
 
-                    return (int)gainInfo.Options().Min(o => o.Value);
+                        return (int)gainInfo.Options().Min(o => o.Value);
+                    } catch (Exception ex) {
+                        Logger.Error("Problem getting gain max", ex);
+                        return -1;
+                    }
                 } else {
                     return -1;
                 }
@@ -582,6 +592,10 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public void SetBinning(short x, short y) {
             // Ignore
+        }
+        
+        public void UpdateSubSampleArea() {
+            throw new NotImplementedException();
         }
 
         #endregion

--- a/NINASonyCameraPlugin.csproj
+++ b/NINASonyCameraPlugin.csproj
@@ -12,7 +12,7 @@
     <Reference Include="ReachFramework" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NINA.Plugin" Version="3.0.0.3001-rc" />
+    <PackageReference Include="NINA.Plugin" Version="3.2.0.3001-rc" />
     <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.6.0-preview3.19128.7" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
@@ -21,7 +21,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Accord" Version="3.8.2-alpha" />
@@ -29,21 +28,10 @@
     <PackageReference Include="Accord.Math" Version="3.8.2-alpha" />
     <PackageReference Include="Accord.Statistics" Version="3.8.2-alpha" />
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
-    <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />
     <PackageReference Include="CommonServiceLocator" Version="2.0.7" />
     <PackageReference Include="CSharpFITS" Version="1.1.0" />
-    <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Dirkster.AvalonDock" Version="4.72.1" />
-    <PackageReference Include="DotNetProjects.Extended.Wpf.Toolkit" Version="5.0.113" />
-    <PackageReference Include="Fastenshtein" Version="1.0.0.8" />
-    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.25.1" />
-    <PackageReference Include="Grpc.Core.Api" Version="2.60.0" />
-    <PackageReference Include="GrpcDotNetNamedPipes" Version="3.0.0" />
-    <PackageReference Include="K4os.Compression.LZ4" Version="1.3.7-beta" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.77" />
-    <PackageReference Include="Namotion.Reflection" Version="3.1.1" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
@@ -55,17 +43,12 @@
     <PackageReference Include="Nito.Disposables" Version="2.5.0" />
     <PackageReference Include="Nito.Mvvm.Async" Version="1.0.0-pre-04" />
     <PackageReference Include="Nito.Mvvm.Core" Version="1.3.1" />
-    <PackageReference Include="NJsonSchema" Version="11.0.0" />
-    <PackageReference Include="OxyPlot.Core" Version="2.1.2" />
-    <PackageReference Include="OxyPlot.Wpf" Version="2.1.2" />
+
+
     <PackageReference Include="SHA3" Version="1.0.0" />
     <PackageReference Include="SharpGIS.NmeaParser" Version="2.2.2" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
-    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.118" />
     <PackageReference Include="System.Windows.Interactivity.WPF" Version="2.0.20525" />
     <PackageReference Include="ToggleSwitch" Version="1.2.0" />
-    <PackageReference Include="Trinet.Core.IO.Ntfs" Version="4.1.1" />
     <PackageReference Include="VVVV.FreeImage" Version="3.15.1.1" />
     <PackageReference Include="Zlib.Portable.Signed" Version="1.11.0" />
   </ItemGroup>
@@ -99,6 +82,6 @@
   </ItemGroup>
   <PropertyGroup />
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="if not exist &quot;%25localappdata%25\NINA\Plugins&quot; (&#xD;&#xA;  echo &quot;Creating $(PlatformName) Plugins folder&quot;&#xD;&#xA;  mkdir &quot;%25localappdata%25\NINA\Plugins&quot;&#xD;&#xA;)&#xD;&#xA;if not exist &quot;%25localappdata%25\NINA\Plugin\3.0.0\$(TargetName)&quot; (&#xD;&#xA;  echo &quot;Creating $(PlatformName) Plugins\3.0.0\$(TargetName) folder&quot;&#xD;&#xA;  mkdir &quot;%25localappdata%25\NINA\Plugins\$(TargetName)&quot;&#xD;&#xA;)&#xD;&#xA;&#xD;&#xA;echo &quot;Copying $(PlatformName) $(TargetFileName)&quot;&#xD;&#xA;xcopy &quot;$(TargetPath)&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\$(TargetName)&quot; /h/i/c/k/e/r/y" />
+    <Exec Command="if not exist &quot;%25localappdata%25\NINA\Plugins\3.0.0&quot; (&#xA;  echo &quot;Creating $(PlatformName) Plugins folder&quot;&#xA;  mkdir &quot;%25localappdata%25\NINA\Plugins\3.0.0&quot;&#xA;)&#xA;if not exist &quot;%25localappdata%25\NINA\Plugins\3.0.0\$(TargetName)&quot; (&#xA;  echo &quot;Creating $(PlatformName) Plugins $(TargetName) folder&quot;&#xA;  mkdir &quot;%25localappdata%25\NINA\Plugins\3.0.0\$(TargetName)&quot;&#xA;)&#xA;&#xA;echo &quot;Copying $(PlatformName) $(TargetFileName)&quot;&#xA;xcopy &quot;$(TargetPath)&quot; &quot;%25localappdata%25\NINA\Plugins\3.0.0\$(TargetName)&quot; /h/i/c/k/e/r/y" />
   </Target>
 </Project>


### PR DESCRIPTION
1. Make plugin work with the latest nightly version of NINA. Add missing method
2. Somehow Sony A6600 doesn't provide list of ISOs, so plugin can't initialize. Make it safer
3. This makes minimum required NINA version to 3.2

fixes #6 #2 (haha, by me)