### PR TITLE
Add cancel guard and plugin configuration option to still use camera native cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,31 @@
-﻿# Sony Camera Plugin
+# Sony Camera Plugin
+
+## 1.0.0.5
+
+- Added native cancel option in plugin settings and defaulted to off to avoid crashes.
+- Serialized capture cancel/start/status checks and treated busy starts as soft cancels.
+- Prevented new exposures from starting when the camera is busy; improved abort behavior without native cancel.
 
 ## 1.0.0.4
-* Added the `UpdateSubSampleArea` implementation and bumped the minimum NINA version so the plugin loads in 3.2.
-* Restored the ISO/Gain UI by notifying NINA whenever the camera connection updates ISO data and by handling cameras without ISO option lists.
-* Probed the registry ISO property (`0xFFFE`) so older Sony bodies still populate the gain dropdown.
-* Logged clearer errors when gain min/max cannot be determined and improved the GitHub workflow to publish the release DLL artifact.
+
+- Added the `UpdateSubSampleArea` implementation and bumped the minimum NINA version so the plugin loads in 3.2.
+- Restored the ISO/Gain UI by notifying NINA whenever the camera connection updates ISO data and by handling cameras without ISO option lists.
+- Probed the registry ISO property (`0xFFFE`) so older Sony bodies still populate the gain dropdown.
+- Logged clearer errors when gain min/max cannot be determined and improved the GitHub workflow to publish the release DLL artifact.
 
 ## 1.0.0.3
+
 Updated to support new device property "DisplayName" required in NINA 3
 
 ## 1.0.0.2
+
 Rebuilt using .NET Core 8 for NINA 3
 
 ## 1.0.0.1
+
 Initial release - Supports all functionality provided by the ASCOM version, plus:
-* LiveView support
-* Actual ISO values displayed in Gain drop-down vs a numeric index (1, 2, 3, etc)
+
+- LiveView support
+- Actual ISO values displayed in Gain drop-down vs a numeric index (1, 2, 3, etc)
 
 Note that NINA saves the raw ARW files and does not generate FITS files for DSLRs (per the note in NINA: Options.Imaging).

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -568,7 +568,6 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             if (_camera != null) {
                 SonyDriver driver = SonyDriver.GetInstance();
                 lock (_captureLock) {
-                    bool issuedCancel = false;
                     _softCancelRequested = false;
                     if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
                         Logger.Warning("Cannot start exposure: capture status unavailable.");
@@ -577,16 +576,10 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
                     if (BUSY_STATES.Contains(captureStatus)) {
                         if (_enableNativeCancel) {
-                            try {
-                                Logger.Info($"Cancelling existing capture before starting new one; status {captureStatus}");
-                                driver.CancelCapture(_camera.Handle);
-                                issuedCancel = true;
-                                if (!TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel")) {
-                                    Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
-                                    throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
-                                }
-                            } catch (Exception ex) {
-                                Logger.Error("CancelCapture failed before start", ex);
+                            TryCancelCapture("start exposure reset");
+                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel")) {
+                                Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
+                                throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
                             }
                         }
                         if (BUSY_STATES.Contains(captureStatus)) {
@@ -601,10 +594,9 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                     }
 
                     // Reset capture state for bodies that require a pre-start cancel, but only when native cancel is enabled.
-                    if (_enableNativeCancel && !issuedCancel) {
+                    if (_enableNativeCancel) {
                         try {
                             driver.CancelCapture(_camera.Handle);
-                            issuedCancel = true;
                         } catch (Exception ex) {
                             Logger.Warning($"Pre-start CancelCapture failed; continuing start. {ex.Message}");
                         }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -47,7 +47,6 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private readonly PluginOptionsAccessor _pluginSettings;
         private readonly bool _enableNativeCancelDefault;
         private bool _softCancelRequested;
-        private bool _abortWarningShown;
 
         private SonyCameraInfo _camera = null;
         private SonyDevice _device = null;
@@ -66,7 +65,6 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             _pluginSettings = pluginSettings;
             _enableNativeCancelDefault = enableNativeCancel;
             _softCancelRequested = false;
-            _abortWarningShown = false;
         }
 
         #region Internal Helpers
@@ -610,7 +608,6 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                 double exposureTime;
                 lock (_captureLock) {
                     _softCancelRequested = false;
-                    _abortWarningShown = false;
                     if (!TryGetCaptureStatus(driver, out var captureStatus, "start exposure preflight") ||
                         captureStatus == CAPTURE_STATUS_UNKNOWN) {
                         Logger.Warning("Cannot start exposure: capture status unavailable.");
@@ -651,10 +648,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             }
 
             _softCancelRequested = true;
-            if (!_abortWarningShown) {
-                Notification.ShowWarning("Abort requested; native cancel is disabled or the camera did not accept it. Exposure will continue until it finishes.");
-                _abortWarningShown = true;
-            }
+            Notification.ShowWarning("Abort requested; native cancel is disabled or the camera did not accept it. Exposure will continue until it finishes.");
             Logger.Info("AbortExposure requested; native cancel unavailable; letting capture finish.");
         }
 

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -571,10 +571,22 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                     _softCancelRequested = false;
                     if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
                         Logger.Warning("Starting exposure without capture status due to read failure.");
-                    } else if (captureStatus == CAPTURE_CAPTURING || captureStatus == CAPTURE_PROCESSING || captureStatus == CAPTURE_STARTING ||
-                        captureStatus == CAPTURE_READING || captureStatus == CAPTURE_PROCESSING) {
-                        Notification.ShowWarning("Another exposure still in progress. Cancelling it to start another.");
-                        shouldCancel = true;
+                    } else {
+                        uint[] idleStates = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
+                        uint[] busyStates = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
+
+                        if (busyStates.Contains(captureStatus)) {
+                            Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
+                            if (_enableNativeCancel) {
+                                shouldCancel = true;
+                            } else {
+                                // Do not attempt to start while camera is busy when native cancel is disabled
+                                return;
+                            }
+                        } else if (!idleStates.Contains(captureStatus)) {
+                            Logger.Warning($"Unexpected capture status {captureStatus} before start; skipping start.");
+                            return;
+                        }
                     }
                 }
 

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -570,17 +570,20 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                 lock (_captureLock) {
                     _softCancelRequested = false;
                     if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
-                        throw new SonyException("Cannot start exposure: capture status unavailable.");
+                        Logger.Warning("Cannot start exposure: capture status unavailable.");
+                        throw new TaskCanceledException("Cannot start exposure: capture status unavailable.");
                     } else {
                         if (BUSY_STATES.Contains(captureStatus)) {
                             if (_enableNativeCancel) {
                                 TryCancelCapture("start exposure reset");
                             }
-                            throw new SonyException("Cannot start exposure: Camera is still busy with a previous exposure.");
+                            Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
+                            throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
                         }
 
                         if (!IDLE_STATES.Contains(captureStatus)) {
-                            throw new SonyException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
+                            Logger.Warning($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
+                            throw new TaskCanceledException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
                         }
                     }
                 }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -782,6 +782,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             else
             {
                 _softCancelRequested = true;
+                Notification.ShowWarning("Abort requested; native cancel is disabled. Exposure will continue until it finishes.");
                 Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
             }
         }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -1,863 +1,723 @@
-﻿namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+using FTD2XX_NET;
+using NINA.Core.Enum;
+using NINA.Core.Model.Equipment;
+using NINA.Core.Utility;
+using NINA.Core.Utility.Notification;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Model;
+using NINA.Equipment.SDK.CameraSDKs.ASTPANSDK;
+using NINA.Equipment.Utility;
+using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
+using NINA.Profile;
+using NINA.Profile.Interfaces;
+using Sony;
 
-public class CameraDriver : BaseINPC, ICamera
-{
-    #region constants
-    private const uint CAPTURE_CANCELLED = 0x0003;
-    private const uint CAPTURE_CAPTURING = 0x0001;
-    private const uint CAPTURE_COMPLETE = 0x0004;
+namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
+    public class CameraDriver : BaseINPC, ICamera {
+        // Some camera settings we are interested in
+        private const uint PROPID_BATTERY = 53784;
+        private const uint PROPID_ISO = 0xD21E; // Actual ISO currently set
+        private const uint PROPID_ISOS = 0xFFFE; // Registry-backed list of learnt ISOs (may be empty until learnt)
 
-    // Registry-backed list of learnt ISOs (may be empty until learnt)
+        // Capture Status
+        private const uint CAPTURE_CREATED    = 0x0000;
+        private const uint CAPTURE_CAPTURING  = 0x0001;
+        private const uint CAPTURE_FAILED     = 0x0002;
+        private const uint CAPTURE_CANCELLED  = 0x0003;
+        private const uint CAPTURE_COMPLETE   = 0x0004;
+        private const uint CAPTURE_STARTING   = 0x8001;
+        private const uint CAPTURE_READING    = 0x8002;
+        private const uint CAPTURE_PROCESSING = 0x8003;
+        private static readonly uint[] IDLE_STATES = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
+        private static readonly uint[] BUSY_STATES = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
+        private static readonly uint[] CANCELLABLE_STATES = BUSY_STATES;
+        private readonly bool _enableNativeCancel;
+        private bool _softCancelRequested;
 
-    // Capture Status
-    private const uint CAPTURE_CREATED = 0x0000;
+        private SonyCameraInfo _camera = null;
+        private SonyDevice _device = null;
+        private IProfileService _profileService;
+        private readonly IExposureDataFactory _exposureDataFactory;
+        private bool _liveViewEnabled;
+        private short _readoutModeForSnapImages;
+        private short _readoutModeForNormalImages;
+        private AsyncObservableCollection<BinningMode> _binningModes;
+        private readonly object _captureLock = new object();
 
-    private const uint CAPTURE_FAILED = 0x0002;
-    private const uint CAPTURE_PROCESSING = 0x8003;
-    private const uint CAPTURE_READING = 0x8002;
-    private const uint CAPTURE_STARTING = 0x8001;
-
-    // Some camera settings we are interested in
-    private const uint PROPID_BATTERY = 53784;
-
-    private const uint PROPID_ISO = 0xD21E;
-
-    // Actual ISO currently set
-    private const uint PROPID_ISOS = 0xFFFE;
-
-    #endregion
-
-    #region properties
-
-    public int BatteryLevel
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return (int)GetPropertyValue(PROPID_BATTERY).Value;
-            }
-            else
-            {
-                return 0;
-            }
-        }
-    }
-
-    public short BayerOffsetX { get => 1; set => throw new NotImplementedException(); }
-    public short BayerOffsetY { get => 1; set => throw new NotImplementedException(); }
-
-    public AsyncObservableCollection<BinningMode> BinningModes
-    {
-        get
-        {
-            if (_binningModes == null)
-            {
-                _binningModes = new AsyncObservableCollection<BinningMode>();
-                _binningModes.Add(new BinningMode(1, 1));
-            }
-
-            return _binningModes;
-        }
-    }
-
-    public short BinX { get => 1; set => throw new NotImplementedException(); }
-    public short BinY { get => 1; set => throw new NotImplementedException(); }
-
-    public int BitDepth
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return _camera.BitsPerPixel;
-            }
-            else
-            {
-                return 0;
-            }
-        }
-    }
-
-    public CameraStates CameraState => CameraStates.NoState;
-
-    public int CameraXSize
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return _camera.ImageSize.Width;
-            }
-            else
-            {
-                return 0;
-            }
-        }
-    }
-
-    public int CameraYSize
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return _camera.ImageSize.Height;
-            }
-            else
-            {
-                return 0;
-            }
-        }
-    }
-
-    public bool CanGetGain => GetAvailableIsoOptions().Any();
-    public bool CanSetGain => CanGetGain;
-    public bool CanSetOffset => false;
-    public bool CanSetTemperature => false;
-    public bool CanSetUSBLimit => false;
-
-    // TODO
-
-    public bool CanShowLiveView
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return _camera.SupportsPreview();
-            }
-            else
-            {
-                return false;
-            }
-        }
-    }
-
-    public bool CanSubSample => false;
-    public string Category { get => "Sony"; }
-
-    public bool Connected
-    {
-        get
-        {
-            return _camera != null;
-        }
-    }
-
-    public bool CoolerOn
-    {
-        get => false;
-        set
-        {
-        }
-    }
-
-    public double CoolerPower => double.NaN;
-
-    public string Description
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return _camera.GetDescription();
-            }
-            else
-            {
-                return _device.GetDescription();
-            }
-        }
-    }
-
-    public bool DewHeaterOn
-    {
-        get => false;
-        set
-        {
-        }
-    }
-
-    public string DisplayName
-    {
-        get => _device.Model;
-        set => throw new NotImplementedException();
-    }
-
-    public string DriverInfo => "https://retro.kiwi";
-    public string DriverVersion => string.Empty;
-    public double ElectronsPerADU => double.NaN;
-    public bool EnableSubSample { get; set; }
-
-    public double ExposureMax
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return _camera.ExposureMax;
-            }
-            else
-            {
-                return double.NaN;
-            }
-        }
-    }
-
-    public double ExposureMin
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return _camera.ExposureMin;
-            }
-            else
-            {
-                return double.NaN;
-            }
-        }
-    }
-
-    public int Gain
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                try
-                {
-                    PropertyValue value = GetPropertyValue(PROPID_ISO);
-
-                    return (int)(value.Value == 0xffffff ? 0 : value.Value);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error("Problem getting gain", ex);
-                    return -1;
-                }
-            }
-            else
-            {
-                return -1;
-            }
+        public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, bool enableNativeCancel) {
+            _profileService = profileService;
+            _exposureDataFactory = exposureDataFactory;
+            _device = device;
+            _enableNativeCancel = enableNativeCancel;
+            _softCancelRequested = false;
         }
 
-        set
-        {
-            if (_camera != null)
-            {
-                try
-                {
-                    SonyDriver.GetInstance().SetProperty(_camera.Handle, PROPID_ISO, (uint)value);
-                    RaisePropertyChanged(nameof(Gain));
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error($"Problem setting gain to {value}", ex);
-                }
-            }
+        #region Internal Helpers
+
+        private PropertyValue GetPropertyValue(uint id) {
+            return SonyDriver.GetInstance().GetProperty(_camera.Handle, id);
         }
-    }
 
-    public int GainMax
-    {
-        get
-        {
-            var isoOptions = GetAvailableIsoOptions();
-            if (!isoOptions.Any())
-            {
-                if (_camera != null)
-                {
-                    Logger.Error("Problem getting gain max: camera did not report ISO options.");
-                }
-                return -1;
+        private IReadOnlyList<PropertyValueOption> GetAvailableIsoOptions() {
+            if (_camera == null) {
+                return Array.Empty<PropertyValueOption>();
             }
 
-            return (int)isoOptions.Last().Value;
-        }
-    }
+            uint[] propertyCandidates = { PROPID_ISOS, PROPID_ISO };
 
-    public int GainMin
-    {
-        get
-        {
-            var isoOptions = GetAvailableIsoOptions();
-            if (!isoOptions.Any())
-            {
-                if (_camera != null)
-                {
-                    Logger.Error("Problem getting gain min: camera did not report ISO options.");
-                }
-                return -1;
-            }
-
-            return (int)isoOptions.Min(o => o.Value);
-        }
-    }
-
-    public IList<int> Gains
-    {
-        get
-        {
-            List<int> gains = new List<int>();
-
-            foreach (var iso in GetAvailableIsoOptions())
-            {
-                if (iso.Value == 0xffffff)
-                {
-                    gains.Add(0); // AUTO
-                }
-                else
-                {
-                    gains.Add((int)iso.Value);
-                }
-            }
-
-            return gains;
-        }
-    }
-
-    public bool HasBattery => true;
-    public bool HasDewHeater => false;
-
-    // TODO!!! WE NEED ONE
-    public bool HasSetupDialog => false;
-
-    public bool HasShutter => true;
-    public string Id => "Sony";
-
-    public bool LiveViewEnabled
-    {
-        get => _liveViewEnabled;
-        set
-        {
-            _liveViewEnabled = value;
-            RaisePropertyChanged();
-        }
-    }
-
-    public short MaxBinX { get => 1; set => throw new NotImplementedException(); }
-    public short MaxBinY { get => 1; set => throw new NotImplementedException(); }
-
-    public string Name
-    {
-        get => _device.Model;
-        set => throw new NotImplementedException();
-    }
-
-    public int Offset { get => -1; set => throw new NotImplementedException(); }
-    public int OffsetMax => 0;
-    public int OffsetMin => 0;
-
-    public double PixelSizeX
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return _camera.PixelWidth;
-            }
-            else
-            {
-                return double.NaN;
-            }
-        }
-    }
-
-    public double PixelSizeY
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return _camera.PixelHeight;
-            }
-            else
-            {
-                return double.NaN;
-            }
-        }
-    }
-
-    public short ReadoutMode
-    {
-        get => 0;
-        set { }
-    }
-
-    public short ReadoutModeForNormalImages
-    {
-        get => _readoutModeForNormalImages;
-        set
-        {
-            _readoutModeForNormalImages = value;
-            RaisePropertyChanged();
-        }
-    }
-
-    public short ReadoutModeForSnapImages
-    {
-        get => _readoutModeForSnapImages;
-        set
-        {
-            _readoutModeForSnapImages = value;
-            RaisePropertyChanged();
-        }
-    }
-
-    public IList<string> ReadoutModes => new List<string> { "Default" };
-
-    public string SensorName
-    {
-        get
-        {
-            if (_camera != null)
-            {
-                return _camera.SensorName;
-            }
-            else
-            {
-                return string.Empty;
-            }
-        }
-    }
-
-    public SensorType SensorType { get => SensorType.RGGB; set => throw new NotImplementedException(); }
-    public int SubSampleHeight { get; set; }
-    public int SubSampleWidth { get; set; }
-    public int SubSampleX { get; set; }
-    public int SubSampleY { get; set; }
-    public IList<string> SupportedActions => new List<string>();
-
-    // Although the driver supports camera temperature, it gets it from the ARW's
-    // metadata after a photo is taken, because this code doesn't request processed
-    // ARW, the temp cannot be determined.
-    public double Temperature
-    {
-        get => double.NaN;
-        /*{
-
-            if (_camera != null) {
-                PropertyValue value = GetPropertyValue(PROPID_TEMPERATURE);
-
-                return (value.Value) / 10.0;
-            } else {
-                return double.NaN;
-            }
-        }*/
-    }
-
-    public double TemperatureSetPoint
-    {
-        get => double.NaN;
-
-        set
-        {
-        }
-    }
-
-    public int USBLimit { get => -1; set => throw new NotImplementedException(); }
-    public int USBLimitMax => -1;
-    public int USBLimitMin => -1;
-    public int USBLimitStep => -1;
-    #endregion
-
-    #region fields
-    private AsyncObservableCollection<BinningMode> _binningModes;
-    private SonyCameraInfo _camera = null;
-    private readonly object _captureLock = new object();
-    private SonyDevice _device = null;
-    private readonly bool _enableNativeCancel;
-    private readonly IExposureDataFactory _exposureDataFactory;
-    private bool _liveViewEnabled;
-    private IProfileService _profileService;
-    private short _readoutModeForNormalImages;
-    private short _readoutModeForSnapImages;
-    private bool _softCancelRequested;
-    private static readonly uint[] BUSY_STATES = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
-    private static readonly uint[] CANCELLABLE_STATES = BUSY_STATES;
-    private static readonly uint[] IDLE_STATES = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
-    #endregion
-
-    public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, bool enableNativeCancel)
-    {
-        _profileService = profileService;
-        _exposureDataFactory = exposureDataFactory;
-        _device = device;
-        _enableNativeCancel = enableNativeCancel;
-        _softCancelRequested = false;
-    }
-
-    #region methods
-
-    public void AbortExposure()
-    {
-        if (_enableNativeCancel)
-        {
-            TryCancelCapture("abort request");
-        }
-        else
-        {
-            _softCancelRequested = true;
-            Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
-        }
-    }
-
-    public string Action(string actionName, string actionParameters)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<bool> Connect(CancellationToken token)
-    {
-        return Task.Run<bool>(() =>
-        {
-            try
-            {
-                _camera = SonyDriver.GetInstance().OpenCamera(_device.Id);
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-                _camera = null;
-            }
-
-            NotifyGainPropertiesChanged();
-            return _camera != null;
-        });
-    }
-
-    public void Disconnect()
-    {
-        if (_camera != null)
-        {
-            try
-            {
-                SonyDriver.GetInstance().CloseCamera(_camera.Handle);
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-            }
-
-            _camera = null;
-            NotifyGainPropertiesChanged();
-        }
-    }
-
-    public Task<IExposureData> DownloadExposure(CancellationToken token)
-    {
-        return Task.Run<IExposureData>(() =>
-        {
-            byte[] rawImageData = SonyDriver.GetInstance().GetLastImage();
-
-            var metaData = new ImageMetaData();
-
-            return _exposureDataFactory.CreateRAWExposureData(
-                converter: _profileService.ActiveProfile.CameraSettings.RawConverter,
-                rawBytes: rawImageData,
-                rawType: "arw",
-                bitDepth: this.BitDepth,
-                metaData: metaData);
-        });
-    }
-
-    public Task<IExposureData> DownloadLiveView(CancellationToken token)
-    {
-        return Task.Run<IExposureData>(() =>
-        {
-            using (var memStream = new MemoryStream(SonyDriver.GetInstance().GetLiveView(_camera.Handle)))
-            {
-                memStream.Position = 0;
-
-                JpegBitmapDecoder decoder =
-                    new JpegBitmapDecoder(memStream, BitmapCreateOptions.IgnoreColorProfile, BitmapCacheOption.OnLoad);
-
-                FormatConvertedBitmap bitmap = new FormatConvertedBitmap();
-                bitmap.BeginInit();
-                bitmap.Source = decoder.Frames[0];
-                bitmap.DestinationFormat = System.Windows.Media.PixelFormats.Gray16;
-                bitmap.EndInit();
-
-                ushort[] outArray = new ushort[bitmap.PixelWidth * bitmap.PixelHeight];
-                bitmap.CopyPixels(outArray, 2 * bitmap.PixelWidth, 0);
-
-                var metaData = new ImageMetaData();
-
-                return _exposureDataFactory.CreateImageArrayExposureData(
-                    input: outArray,
-                    width: bitmap.PixelWidth,
-                    height: bitmap.PixelHeight,
-                    bitDepth: 16,
-                    isBayered: false,
-                    metaData: metaData);
-            }
-        });
-    }
-
-    public void SendCommandBlind(string command, bool raw = true)
-    {
-        throw new NotImplementedException();
-    }
-
-    public bool SendCommandBool(string command, bool raw = true)
-    {
-        throw new NotImplementedException();
-    }
-
-    public string SendCommandString(string command, bool raw = true)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void SetBinning(short x, short y)
-    {
-        // Ignore
-    }
-
-    public void SetupDialog()
-    {
-        throw new NotImplementedException();
-    }
-
-    public void StartExposure(CaptureSequence sequence)
-    {
-        if (_camera != null)
-        {
-            SonyDriver driver = SonyDriver.GetInstance();
-            lock (_captureLock)
-            {
-                _softCancelRequested = false;
-                if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight"))
-                {
-                    Logger.Warning("Cannot start exposure: capture status unavailable.");
-                    throw new TaskCanceledException("Cannot start exposure: capture status unavailable.");
-                }
-
-
-
-
-
-                if (BUSY_STATES.Contains(captureStatus))
-                {
-                    if (_enableNativeCancel)
-                    {
-                        TryCancelCapture("start exposure reset");
+            foreach (var propertyId in propertyCandidates) {
+                try {
+                    var options = _camera.GetPropertyInfo(propertyId)?.Options()?.Where(o => o.Value <= 0x00FFFFFF).ToList();
+                    if (options != null && options.Count > 0) {
+                        return options;
                     }
-                    Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
-                    throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
-                }
-
-                if (!IDLE_STATES.Contains(captureStatus))
-                {
-                    Logger.Warning($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
-                    throw new TaskCanceledException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
-                }
-
-                double exposureTime = sequence.ExposureTime;
-                driver.StartCapture(_camera.Handle, (float)exposureTime);
-            }
-        }
-    }
-
-    public void StartLiveView(CaptureSequence sequence)
-    {
-        LiveViewEnabled = true;
-    }
-
-    public void StopExposure()
-    {
-        AbortExposure();
-    }
-
-    public void StopLiveView()
-    {
-        LiveViewEnabled = false;
-    }
-
-    public void UpdateSubSampleArea()
-    {
-        if (_camera == null)
-        {
-            EnableSubSample = false;
-            SubSampleX = 0;
-            SubSampleY = 0;
-            SubSampleWidth = 0;
-            SubSampleHeight = 0;
-            return;
-        }
-
-        if (EnableSubSample && !CanSubSample)
-        {
-            Logger.Warning("Sub-sampling requested but not supported for Sony cameras. Falling back to full frame.");
-            EnableSubSample = false;
-        }
-
-        // Sony cameras currently expose the entire frame, so always reset to the sensor dimensions.
-        SubSampleX = 0;
-        SubSampleY = 0;
-        SubSampleWidth = _camera.ImageSize.Width;
-        SubSampleHeight = _camera.ImageSize.Height;
-    }
-
-    public async Task WaitUntilExposureIsReady(CancellationToken token)
-    {
-        using (token.Register(AbortExposure))
-        {
-            uint[] completionStates = { CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
-
-            SonyDriver driver = SonyDriver.GetInstance();
-
-            try
-            {
-                uint captureStatus;
-                lock (_captureLock)
-                {
-                    if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait begin"))
-                    {
-                        throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
-                    }
-                }
-                Logger.Info(
-                    $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", completionStates)}");
-
-                while (!completionStates.Contains(captureStatus))
-                {
-                    await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), token);
-                    if (!_enableNativeCancel && token.IsCancellationRequested)
-                    {
-                        _softCancelRequested = true;
-                    }
-
-                    lock (_captureLock)
-                    {
-                        if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll"))
-                        {
-                            throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
-                        }
-                    }
-                }
-
-                Logger.Info($"Wait for image ready complete, completion state is {captureStatus}");
-                if (_softCancelRequested || token.IsCancellationRequested)
-                {
-                    _softCancelRequested = false;
-                    throw new TaskCanceledException("Exposure cancelled by user (soft cancel).");
+                } catch (Exception ex) {
+                    Logger.Warning($"Unable to enumerate ISO options for property 0x{propertyId:X}: {ex.Message}");
                 }
             }
-            catch (TaskCanceledException)
-            {
-                Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Logger.Error("WaitUntilExposureIsReady got exception", ex);
-                throw new SonyException("Problem while waiting for image to be ready (see log)");
-            }
-        }
-    }
 
-    private IReadOnlyList<PropertyValueOption> GetAvailableIsoOptions()
-    {
-        if (_camera == null)
-        {
+            Logger.Warning("Camera did not report any ISO options via known properties (registry ISO list may be empty until the camera learns it).");
             return Array.Empty<PropertyValueOption>();
         }
 
-        uint[] propertyCandidates = { PROPID_ISOS, PROPID_ISO };
+        private void NotifyGainPropertiesChanged() {
+            RaisePropertyChanged(nameof(CanGetGain));
+            RaisePropertyChanged(nameof(CanSetGain));
+            RaisePropertyChanged(nameof(GainMin));
+            RaisePropertyChanged(nameof(GainMax));
+            RaisePropertyChanged(nameof(Gain));
+            RaisePropertyChanged(nameof(Gains));
+        }
 
-        foreach (var propertyId in propertyCandidates)
-        {
-            try
-            {
-                var options = _camera.GetPropertyInfo(propertyId)?.Options()?.Where(o => o.Value <= 0x00FFFFFF).ToList();
-                if (options != null && options.Count > 0)
-                {
-                    return options;
-                }
+        private bool TryCancelCapture(string reason) {
+            if (_camera == null) {
+                return false;
             }
-            catch (Exception ex)
-            {
-                Logger.Warning($"Unable to enumerate ISO options for property 0x{propertyId:X}: {ex.Message}");
+
+            if (!_enableNativeCancel) {
+                Logger.Info($"Native cancel disabled; skipping cancel ({reason})");
+                return false;
             }
-        }
 
-        Logger.Warning("Camera did not report any ISO options via known properties (registry ISO list may be empty until the camera learns it).");
-        return Array.Empty<PropertyValueOption>();
-    }
+            lock (_captureLock) {
+                try {
+                    SonyDriver driver = SonyDriver.GetInstance();
+                    if (!TryGetCaptureStatusLocked(driver, out var status, reason)) {
+                        return false;
+                    }
 
-    private PropertyValue GetPropertyValue(uint id)
-    {
-        return SonyDriver.GetInstance().GetProperty(_camera.Handle, id);
-    }
+                    if (!CANCELLABLE_STATES.Contains(status)) {
+                        Logger.Debug($"Skip cancel ({reason}); capture status is {status}");
+                        return false;
+                    }
 
-    private void NotifyGainPropertiesChanged()
-    {
-        RaisePropertyChanged(nameof(CanGetGain));
-        RaisePropertyChanged(nameof(CanSetGain));
-        RaisePropertyChanged(nameof(GainMin));
-        RaisePropertyChanged(nameof(GainMax));
-        RaisePropertyChanged(nameof(Gain));
-        RaisePropertyChanged(nameof(Gains));
-    }
-
-    private bool TryCancelCapture(string reason)
-    {
-        if (_camera == null)
-        {
-            return false;
-        }
-
-        if (!_enableNativeCancel)
-        {
-            Logger.Info($"Native cancel disabled; skipping cancel ({reason})");
-            return false;
-        }
-
-        lock (_captureLock)
-        {
-            try
-            {
-                SonyDriver driver = SonyDriver.GetInstance();
-                if (!TryGetCaptureStatusLocked(driver, out var status, reason))
-                {
+                    Logger.Info($"Issuing cancel ({reason}); capture status is {status}");
+                    driver.CancelCapture(_camera.Handle);
+                    return true;
+                } catch (Exception ex) {
+                    Logger.Error($"CancelCapture failed ({reason})", ex);
                     return false;
                 }
+            }
+        }
 
-                if (!CANCELLABLE_STATES.Contains(status))
-                {
-                    Logger.Debug($"Skip cancel ({reason}); capture status is {status}");
-                    return false;
-                }
-
-                Logger.Info($"Issuing cancel ({reason}); capture status is {status}");
-                driver.CancelCapture(_camera.Handle);
+        private bool TryGetCaptureStatusLocked(SonyDriver driver, out uint status, string reason) {
+            try {
+                status = driver.GetCaptureStatus(_camera.Handle);
                 return true;
-            }
-            catch (Exception ex)
-            {
-                Logger.Error($"CancelCapture failed ({reason})", ex);
+            } catch (Exception ex) {
+                Logger.Warning($"Unable to get capture status ({reason}): {ex.Message}");
+                status = CAPTURE_FAILED;
                 return false;
             }
         }
-    }
 
-    private bool TryGetCaptureStatusLocked(SonyDriver driver, out uint status, string reason)
-    {
-        try
-        {
-            status = driver.GetCaptureStatus(_camera.Handle);
-            return true;
-        }
-        catch (Exception ex)
-        {
-            Logger.Warning($"Unable to get capture status ({reason}): {ex.Message}");
-            status = CAPTURE_FAILED;
-            return false;
-        }
-    }
+        #endregion
 
-    #endregion 
+        #region Supported Properties
+
+        public bool HasShutter => true;
+
+        // Although the driver supports camera temperature, it gets it from the ARW's
+        // metadata after a photo is taken, because this code doesn't request processed
+        // ARW, the temp cannot be determined.
+        public double Temperature {
+            get => double.NaN;
+            /*{
+
+                if (_camera != null) {
+                    PropertyValue value = GetPropertyValue(PROPID_TEMPERATURE);
+
+                    return (value.Value) / 10.0;
+                } else {
+                    return double.NaN;
+                }
+            }*/
+        }
+
+        public short BinX { get => 1; set => throw new NotImplementedException(); }
+        public short BinY { get => 1; set => throw new NotImplementedException(); }
+
+        public string SensorName {
+            get {
+                if (_camera != null) {
+                    return _camera.SensorName;
+                } else {
+                    return string.Empty;
+                }
+            }
+        }
+
+        public SensorType SensorType { get => SensorType.RGGB; set => throw new NotImplementedException(); }
+
+        public short BayerOffsetX { get => 1; set => throw new NotImplementedException(); }
+
+        public short BayerOffsetY { get => 1; set => throw new NotImplementedException(); }
+
+        public int CameraXSize {
+            get {
+                if (_camera != null) {
+                    return _camera.ImageSize.Width;
+                }
+                else {
+                    return 0;
+                }
+            }
+        }
+
+        public int CameraYSize {
+            get {
+                if (_camera != null) {
+                    return _camera.ImageSize.Height;
+                } else {
+                    return 0;
+                }
+            }
+        }
+
+        public double ExposureMin {
+            get {
+                if (_camera != null) {
+                    return _camera.ExposureMin;
+                } else {
+                    return double.NaN;
+                }
+            }
+        }
+
+        public double ExposureMax {
+            get {
+                if (_camera != null) {
+                    return _camera.ExposureMax;
+                } else {
+                    return double.NaN;
+                }
+            }
+        }
+
+        public short MaxBinX { get => 1; set => throw new NotImplementedException(); }
+
+        public short MaxBinY { get => 1; set => throw new NotImplementedException(); }
+
+        public double PixelSizeX {
+            get {
+                if (_camera != null) {
+                    return _camera.PixelWidth;
+                } else {
+                    return double.NaN;
+                }
+            }
+        }
+
+        public double PixelSizeY {
+            get {
+                if (_camera != null) {
+                    return _camera.PixelHeight;
+                } else {
+                    return double.NaN;
+                }
+            }
+        }
+
+        public bool CanSetTemperature => false;
+
+        public CameraStates CameraState => CameraStates.NoState; // TODO
+
+        public bool CanShowLiveView {
+            get {
+                if (_camera != null) {
+                    return _camera.SupportsPreview();
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        public bool LiveViewEnabled {
+            get => _liveViewEnabled;
+            set {
+                _liveViewEnabled = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public bool HasBattery => true;
+
+        public int BatteryLevel {
+            get {
+                if (_camera != null) {
+                    return (int)GetPropertyValue(PROPID_BATTERY).Value;
+                } else {
+                    return 0;
+                }
+            }
+        }
+
+        public int BitDepth {
+            get {
+                if (_camera != null) {
+                    return _camera.BitsPerPixel;
+                } else {
+                    return 0;
+                }
+            }
+        }
+
+        public bool CanGetGain => GetAvailableIsoOptions().Any();
+
+        public bool CanSetGain => CanGetGain;
+
+        public int GainMax {
+            get {
+                var isoOptions = GetAvailableIsoOptions();
+                if (!isoOptions.Any()) {
+                    if (_camera != null) {
+                        Logger.Error("Problem getting gain max: camera did not report ISO options.");
+                    }
+                    return -1;
+                }
+
+                return (int)isoOptions.Last().Value;
+            }
+        }
+
+        public int GainMin {
+            get {
+                var isoOptions = GetAvailableIsoOptions();
+                if (!isoOptions.Any()) {
+                    if (_camera != null) {
+                        Logger.Error("Problem getting gain min: camera did not report ISO options.");
+                    }
+                    return -1;
+                }
+
+                return (int)isoOptions.Min(o => o.Value);
+            }
+        }
+
+        public int Gain {
+            get {
+                if (_camera != null) {
+                    try {
+                        PropertyValue value = GetPropertyValue(PROPID_ISO);
+
+                        return (int)(value.Value == 0xffffff ? 0 : value.Value);
+                    } catch (Exception ex) {
+                        Logger.Error("Problem getting gain", ex);
+                        return -1;
+                    }
+                } else {
+                    return -1;
+                }
+            }
+
+            set {
+                if (_camera != null) {
+                    try {
+                        SonyDriver.GetInstance().SetProperty(_camera.Handle, PROPID_ISO, (uint)value);
+                        RaisePropertyChanged(nameof(Gain));
+                    } catch (Exception ex) {
+                        Logger.Error($"Problem setting gain to {value}", ex);
+                    }
+                }
+            }
+        }
+
+        public IList<int> Gains {
+            get {
+                List<int> gains = new List<int>();
+
+                foreach (var iso in GetAvailableIsoOptions()) {
+                    if (iso.Value == 0xffffff) {
+                        gains.Add(0); // AUTO
+                    } else {
+                        gains.Add((int)iso.Value);
+                    }
+                }
+
+                return gains;
+            }
+        }
+
+        public string Id => "Sony";
+
+        public string Name {
+            get => _device.Model;
+            set => throw new NotImplementedException();
+        }
+
+        public string DisplayName {
+            get => _device.Model;
+            set => throw new NotImplementedException();
+        }
+
+        public string Category { get => "Sony"; }
+
+        public bool Connected {
+            get {
+                return _camera != null;
+            }
+        }
+
+        public string Description {
+            get {
+                if (_camera != null) {
+                    return _camera.GetDescription();
+                } else {
+                    return _device.GetDescription();
+                }
+            }
+        }
+
+        public string DriverInfo => "https://retro.kiwi";
+
+        public string DriverVersion => string.Empty;
+
+        public double TemperatureSetPoint {
+            get => double.NaN;
+
+            set {
+            }
+        }
+
+        public bool CanSubSample => false;
+
+        public bool EnableSubSample { get; set; }
+
+        public int SubSampleX { get; set; }
+
+        public int SubSampleY { get; set; }
+
+        public int SubSampleWidth { get; set; }
+
+        public int SubSampleHeight { get; set; }
+
+        public bool CoolerOn {
+            get => false;
+            set {
+            }
+        }
+
+        public double CoolerPower => double.NaN;
+
+        public bool HasDewHeater => false;
+
+        public bool DewHeaterOn {
+            get => false;
+            set {
+            }
+        }
+
+        public bool CanSetOffset => false;
+
+        public int Offset { get => -1; set => throw new NotImplementedException(); }
+
+        public int OffsetMin => 0;
+
+        public int OffsetMax => 0;
+
+        public bool CanSetUSBLimit => false;
+
+        public int USBLimit { get => -1; set => throw new NotImplementedException(); }
+
+        public int USBLimitMin => -1;
+
+        public int USBLimitMax => -1;
+
+        public int USBLimitStep => -1;
+
+        public double ElectronsPerADU => double.NaN;
+
+        public IList<string> ReadoutModes => new List<string> { "Default" };
+
+        public short ReadoutMode {
+            get => 0;
+            set { }
+        }
+
+        public short ReadoutModeForSnapImages {
+            get => _readoutModeForSnapImages;
+            set {
+                _readoutModeForSnapImages = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public short ReadoutModeForNormalImages {
+            get => _readoutModeForNormalImages;
+            set {
+                _readoutModeForNormalImages = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public AsyncObservableCollection<BinningMode> BinningModes {
+            get {
+                if (_binningModes == null) {
+                    _binningModes = new AsyncObservableCollection<BinningMode>();
+                    _binningModes.Add(new BinningMode(1, 1));
+                }
+
+                return _binningModes;
+            }
+        }
+
+        #endregion
+
+        #region Supported Methods
+
+        public void StartLiveView(CaptureSequence sequence) {
+            LiveViewEnabled = true;
+        }
+
+        public void StopLiveView() {
+            LiveViewEnabled = false;
+        }
+
+        public Task<bool> Connect(CancellationToken token) {
+            return Task.Run<bool>(() => {
+                try {
+                    _camera = SonyDriver.GetInstance().OpenCamera(_device.Id);
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                    _camera = null;
+                }
+
+                NotifyGainPropertiesChanged();
+                return _camera != null;
+            });
+        }
+
+        public void Disconnect() {
+            if (_camera != null) {
+                try {
+                    SonyDriver.GetInstance().CloseCamera(_camera.Handle);
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                }
+
+                _camera = null;
+                NotifyGainPropertiesChanged();
+            }
+        }
+
+        public Task<IExposureData> DownloadLiveView(CancellationToken token) {
+            return Task.Run<IExposureData>(() => {
+                using (var memStream = new MemoryStream(SonyDriver.GetInstance().GetLiveView(_camera.Handle))) {
+                    memStream.Position = 0;
+
+                    JpegBitmapDecoder decoder =
+                        new JpegBitmapDecoder(memStream, BitmapCreateOptions.IgnoreColorProfile, BitmapCacheOption.OnLoad);
+
+                    FormatConvertedBitmap bitmap = new FormatConvertedBitmap();
+                    bitmap.BeginInit();
+                    bitmap.Source = decoder.Frames[0];
+                    bitmap.DestinationFormat = System.Windows.Media.PixelFormats.Gray16;
+                    bitmap.EndInit();
+
+                    ushort[] outArray = new ushort[bitmap.PixelWidth * bitmap.PixelHeight];
+                    bitmap.CopyPixels(outArray, 2 * bitmap.PixelWidth, 0);
+
+                    var metaData = new ImageMetaData();
+
+                    return _exposureDataFactory.CreateImageArrayExposureData(
+                        input: outArray,
+                        width: bitmap.PixelWidth,
+                        height: bitmap.PixelHeight,
+                        bitDepth: 16,
+                        isBayered: false,
+                        metaData: metaData);
+                }
+            });
+        }
+
+        public void SetupDialog() {
+            throw new NotImplementedException();
+        }
+
+        public void StartExposure(CaptureSequence sequence) {
+            if (_camera != null) {
+                SonyDriver driver = SonyDriver.GetInstance();
+                lock (_captureLock) {
+                    _softCancelRequested = false;
+                    if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
+                        Logger.Warning("Cannot start exposure: capture status unavailable.");
+                        throw new TaskCanceledException("Cannot start exposure: capture status unavailable.");
+                    }
+
+                    if (BUSY_STATES.Contains(captureStatus)) {
+                        if (_enableNativeCancel) {
+                            TryCancelCapture("start exposure reset");
+                        }
+                        Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
+                        throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
+                    }
+
+                    if (!IDLE_STATES.Contains(captureStatus)) {
+                        Logger.Warning($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
+                        throw new TaskCanceledException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
+                    }
+
+                    double exposureTime = sequence.ExposureTime;
+                    driver.StartCapture(_camera.Handle, (float)exposureTime);
+                }
+            }
+        }
+
+        public void StopExposure() {
+            AbortExposure();
+        }
+
+        public void AbortExposure() {
+            if (_enableNativeCancel) {
+                TryCancelCapture("abort request");
+            } else {
+                _softCancelRequested = true;
+                Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
+            }
+        }
+
+        public async Task WaitUntilExposureIsReady(CancellationToken token) {
+            using (token.Register(AbortExposure)) {
+                uint[] completionStates = { CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
+
+                SonyDriver driver = SonyDriver.GetInstance();
+
+                try {
+                    uint captureStatus;
+                    lock (_captureLock) {
+                        if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait begin")) {
+                            throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
+                        }
+                    }
+                    Logger.Info(
+                        $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", completionStates)}");
+
+                    while (!completionStates.Contains(captureStatus)) {
+                        await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), token);
+                        if (!_enableNativeCancel && token.IsCancellationRequested) {
+                            _softCancelRequested = true;
+                        }
+
+                        lock (_captureLock) {
+                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll")) {
+                                throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
+                            }
+                        }
+                    }
+
+                    Logger.Info($"Wait for image ready complete, completion state is {captureStatus}");
+                    if (_softCancelRequested || token.IsCancellationRequested) {
+                        _softCancelRequested = false;
+                        throw new TaskCanceledException("Exposure cancelled by user (soft cancel).");
+                    }
+                } catch (TaskCanceledException) {
+                    Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
+                    throw;
+                } catch (Exception ex) {
+                    Logger.Error("WaitUntilExposureIsReady got exception", ex);
+                    throw new SonyException("Problem while waiting for image to be ready (see log)");
+                }
+            }
+        }
+
+        public Task<IExposureData> DownloadExposure(CancellationToken token) {
+            return Task.Run<IExposureData>(() => {
+                byte[] rawImageData = SonyDriver.GetInstance().GetLastImage();
+
+                var metaData = new ImageMetaData();
+
+                return _exposureDataFactory.CreateRAWExposureData(
+                    converter: _profileService.ActiveProfile.CameraSettings.RawConverter,
+                    rawBytes: rawImageData,
+                    rawType: "arw",
+                    bitDepth: this.BitDepth,
+                    metaData: metaData);
+            });
+        }
+        #endregion
+
+        #region Unsupported Methods
+
+        public string Action(string actionName, string actionParameters) {
+            throw new NotImplementedException();
+        }
+
+
+        public void SendCommandBlind(string command, bool raw = true) {
+            throw new NotImplementedException();
+        }
+
+        public bool SendCommandBool(string command, bool raw = true) {
+            throw new NotImplementedException();
+        }
+
+        public string SendCommandString(string command, bool raw = true) {
+            throw new NotImplementedException();
+        }
+
+        public void SetBinning(short x, short y) {
+            // Ignore
+        }
+        
+        public void UpdateSubSampleArea() {
+            if (_camera == null) {
+                EnableSubSample = false;
+                SubSampleX = 0;
+                SubSampleY = 0;
+                SubSampleWidth = 0;
+                SubSampleHeight = 0;
+                return;
+            }
+
+            if (EnableSubSample && !CanSubSample) {
+                Logger.Warning("Sub-sampling requested but not supported for Sony cameras. Falling back to full frame.");
+                EnableSubSample = false;
+            }
+
+            // Sony cameras currently expose the entire frame, so always reset to the sensor dimensions.
+            SubSampleX = 0;
+            SubSampleY = 0;
+            SubSampleWidth = _camera.ImageSize.Width;
+            SubSampleHeight = _camera.ImageSize.Height;
+        }
+
+        #endregion
+
+
+        // TODO!!! WE NEED ONE
+        public bool HasSetupDialog => false;
+
+        public IList<string> SupportedActions => new List<string>();
+    }
 }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -774,7 +774,10 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
         {
             if (_enableNativeCancel)
             {
-                TryCancelCapture("abort request");
+                if (!TryCancelCapture("abort request"))
+                {
+                    Notification.ShowWarning("Abort requested, but the camera did not accept native cancel; exposure will continue until it finishes.");
+                }
             }
             else
             {

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -100,12 +100,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             lock (_captureLock) {
                 try {
                     SonyDriver driver = SonyDriver.GetInstance();
-                    uint status;
-
-                    try {
-                        status = driver.GetCaptureStatus(_camera.Handle);
-                    } catch (Exception ex) {
-                        Logger.Warning($"Skipping cancel ({reason}) because capture status could not be read: {ex.Message}");
+                    if (!TryGetCaptureStatusLocked(driver, out var status, reason)) {
                         return false;
                     }
 
@@ -122,6 +117,17 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                     Logger.Error($"CancelCapture failed ({reason})", ex);
                     return false;
                 }
+            }
+        }
+
+        private bool TryGetCaptureStatusLocked(SonyDriver driver, out uint status, string reason) {
+            try {
+                status = driver.GetCaptureStatus(_camera.Handle);
+                return true;
+            } catch (Exception ex) {
+                Logger.Warning($"Unable to get capture status ({reason}): {ex.Message}");
+                status = CAPTURE_FAILED;
+                return false;
             }
         }
 
@@ -551,18 +557,25 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         public void StartExposure(CaptureSequence sequence) {
             if (_camera != null) {
                 SonyDriver driver = SonyDriver.GetInstance();
-                uint captureStatus = driver.GetCaptureStatus(_camera.Handle);
-
-                if (captureStatus == CAPTURE_CAPTURING || captureStatus == CAPTURE_PROCESSING || captureStatus == CAPTURE_STARTING ||
-                    captureStatus == CAPTURE_READING || captureStatus == CAPTURE_PROCESSING) {
-                    Notification.ShowWarning("Another exposure still in progress. Cancelling it to start another.");
+                bool shouldCancel = false;
+                lock (_captureLock) {
+                    if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
+                        Logger.Warning("Starting exposure without capture status due to read failure.");
+                    } else if (captureStatus == CAPTURE_CAPTURING || captureStatus == CAPTURE_PROCESSING || captureStatus == CAPTURE_STARTING ||
+                        captureStatus == CAPTURE_READING || captureStatus == CAPTURE_PROCESSING) {
+                        Notification.ShowWarning("Another exposure still in progress. Cancelling it to start another.");
+                        shouldCancel = true;
+                    }
                 }
 
-                // Tell the camera to cancel capture, we do this every time regardless - this will reset the status to be non-complete
-                TryCancelCapture("start exposure reset");
+                if (shouldCancel) {
+                    TryCancelCapture("start exposure reset");
+                }
 
-                double exposureTime = sequence.ExposureTime;
-                driver.StartCapture(_camera.Handle, (float)exposureTime); //);
+                lock (_captureLock) {
+                    double exposureTime = sequence.ExposureTime;
+                    driver.StartCapture(_camera.Handle, (float)exposureTime); //);
+                }
             }
         }
 
@@ -581,13 +594,22 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                 SonyDriver driver = SonyDriver.GetInstance();
 
                 try {
-                    uint captureStatus = driver.GetCaptureStatus(_camera.Handle);
+                    uint captureStatus;
+                    lock (_captureLock) {
+                        if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait begin")) {
+                            throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
+                        }
+                    }
                     Logger.Info(
                         $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", completionStates)}");
 
                     while (!completionStates.Contains(captureStatus)) {
                         await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), token);
-                        captureStatus = driver.GetCaptureStatus(_camera.Handle);
+                        lock (_captureLock) {
+                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll")) {
+                                throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
+                            }
+                        }
                     }
 
                     Logger.Info($"Wait for image ready complete, completion state is {captureStatus}");

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -20,6 +20,7 @@ using NINA.Image.ImageData;
 using NINA.Image.Interfaces;
 using NINA.Profile;
 using NINA.Profile.Interfaces;
+using NINA.RetroKiwi.Plugin.SonyCamera;
 using Sony;
 
 namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
@@ -43,7 +44,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private static readonly uint[] BUSY_STATES = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
         private static readonly uint[] COMPLETION_STATES = { CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
 
-        private readonly bool _enableNativeCancel;
+        private readonly PluginOptionsAccessor _pluginSettings;
+        private readonly bool _enableNativeCancelDefault;
         private bool _softCancelRequested;
 
         private SonyCameraInfo _camera = null;
@@ -56,11 +58,12 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private AsyncObservableCollection<BinningMode> _binningModes;
         private readonly object _captureLock = new object();
 
-        public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, bool enableNativeCancel) {
+        public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, PluginOptionsAccessor pluginSettings, bool enableNativeCancel) {
             _profileService = profileService;
             _exposureDataFactory = exposureDataFactory;
             _device = device;
-            _enableNativeCancel = enableNativeCancel;
+            _pluginSettings = pluginSettings;
+            _enableNativeCancelDefault = enableNativeCancel;
             _softCancelRequested = false;
         }
 
@@ -101,12 +104,29 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             RaisePropertyChanged(nameof(Gains));
         }
 
+        private bool NativeCancelEnabled {
+            get {
+                if (_pluginSettings != null) {
+                    try {
+                        var raw = _pluginSettings.GetValueString(nameof(SonyCamera.EnableNativeCancel), _enableNativeCancelDefault.ToString());
+                        if (bool.TryParse(raw, out var enabled)) {
+                            return enabled;
+                        }
+                    } catch (Exception ex) {
+                        Logger.Warning($"Unable to read EnableNativeCancel setting; defaulting to {_enableNativeCancelDefault}. {ex.Message}");
+                    }
+                }
+
+                return _enableNativeCancelDefault;
+            }
+        }
+
         private bool TryCancelCaptureIfEnabled(string reason) {
             if (_camera == null) {
                 return false;
             }
 
-            if (!_enableNativeCancel) {
+            if (!NativeCancelEnabled) {
                 Logger.Info($"Native cancel disabled; skipping cancel ({reason})");
                 return false;
             }
@@ -584,7 +604,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                     }
 
                     TryCancelCaptureIfEnabled("start exposure reset");
-                    if (_enableNativeCancel && (!TryGetCaptureStatus(driver, out captureStatus, "start exposure post-cancel") || captureStatus == CAPTURE_STATUS_UNKNOWN)) {
+                    if (NativeCancelEnabled && (!TryGetCaptureStatus(driver, out captureStatus, "start exposure post-cancel") || captureStatus == CAPTURE_STATUS_UNKNOWN)) {
                         Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
                         throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
                     }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -744,17 +744,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
                     }
 
                     // Reset capture state for bodies that require a pre-start cancel, but only when native cancel is enabled.
-                    if (_enableNativeCancel)
-                    {
-                        try
-                        {
-                            driver.CancelCapture(_camera.Handle);
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.Warning($"Pre-start CancelCapture failed; continuing start. {ex.Message}");
-                        }
-                    }
+                    TryCancelCaptureIfEnabled("start exposure pre-start reset");
 
                     double exposureTime = sequence.ExposureTime;
                     driver.StartCapture(_camera.Handle, (float)exposureTime);

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -87,7 +87,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                         return options;
                     }
                 } catch (Exception ex) {
-                    Logger.Warning($"Unable to enumerate ISO options for property 0x{propertyId:X}: {ex.Message}");
+                    Logger.Warning($"Unable to enumerate ISO options for property 0x{propertyId:X}: {ex.Message}.");
                 }
             }
 
@@ -113,7 +113,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                             return enabled;
                         }
                     } catch (Exception ex) {
-                        Logger.Warning($"Unable to read EnableNativeCancel setting; defaulting to {_enableNativeCancelDefault}. {ex.Message}");
+                        Logger.Warning($"EnableNativeCancel read failed; defaulting to {_enableNativeCancelDefault}. {ex.Message}.");
                     }
                 }
 
@@ -121,39 +121,48 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             }
         }
 
-        private bool TryCancelCaptureIfEnabled(string reason) {
+        private bool TryCancelCaptureIfEnabled(string reason, int lockTimeoutMs = 1000) {
             if (_camera == null) {
                 return false;
             }
 
             if (!NativeCancelEnabled) {
-                Logger.Info($"Native cancel disabled; skipping cancel ({reason})");
+                Logger.Info($"Native cancel disabled; skipping cancel ({reason}).");
                 return false;
             }
 
-            lock (_captureLock) {
-                try {
-                    SonyDriver driver = SonyDriver.GetInstance();
-                    if (!TryGetCaptureStatus(driver, out var status, reason)) {
-                        return false;
-                    }
-
-                    if (status == CAPTURE_STATUS_UNKNOWN) {
-                        Logger.Warning($"Skip cancel ({reason}); capture status is unknown (camera did not respond).");
-                        return false;
-                    }
-
-                    if (!BUSY_STATES.Contains(status)) {
-                        Logger.Debug($"Skip cancel ({reason}); capture status is {status}");
-                        return false;
-                    }
-
-                    Logger.Info($"Issuing cancel ({reason}); capture status is {status}");
-                    driver.CancelCapture(_camera.Handle);
-                    return true;
-                } catch (Exception ex) {
-                    Logger.Error($"CancelCapture failed ({reason})", ex);
+            bool lockTaken = false;
+            try {
+                if (!Monitor.TryEnter(_captureLock, lockTimeoutMs)) {
+                    Logger.Warning($"Skipping cancel ({reason}); capture lock unavailable after {lockTimeoutMs} ms.");
                     return false;
+                }
+                lockTaken = true;
+
+                SonyDriver driver = SonyDriver.GetInstance();
+                if (!TryGetCaptureStatus(driver, out var status, reason)) {
+                    return false;
+                }
+
+                if (status == CAPTURE_STATUS_UNKNOWN) {
+                    Logger.Warning($"Skipping cancel ({reason}); capture status is unknown (camera did not respond).");
+                    return false;
+                }
+
+                if (!BUSY_STATES.Contains(status)) {
+                    Logger.Debug($"Skipping cancel ({reason}); capture status is {status}.");
+                    return false;
+                }
+
+                Logger.Info($"Issuing cancel ({reason}); capture status is {status}.");
+                driver.CancelCapture(_camera.Handle);
+                return true;
+            } catch (Exception ex) {
+                Logger.Error($"CancelCapture failed ({reason}).", ex);
+                return false;
+            } finally {
+                if (lockTaken) {
+                    Monitor.Exit(_captureLock);
                 }
             }
         }
@@ -163,7 +172,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                 status = driver.GetCaptureStatus(_camera.Handle);
                 return true;
             } catch (Exception ex) {
-                Logger.Warning($"Unable to get capture status ({reason}); camera may not have responded: {ex.Message}");
+                Logger.Warning($"Unable to get capture status ({reason}); camera may not have responded: {ex.Message}.");
                 status = CAPTURE_STATUS_UNKNOWN;
                 return false;
             }
@@ -360,7 +369,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
                         return (int)(value.Value == 0xffffff ? 0 : value.Value);
                     } catch (Exception ex) {
-                        Logger.Error("Problem getting gain", ex);
+                        Logger.Error("Problem getting gain.", ex);
                         return -1;
                     }
                 } else {
@@ -374,7 +383,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                         SonyDriver.GetInstance().SetProperty(_camera.Handle, PROPID_ISO, (uint)value);
                         RaisePropertyChanged(nameof(Gain));
                     } catch (Exception ex) {
-                        Logger.Error($"Problem setting gain to {value}", ex);
+                        Logger.Error($"Problem setting gain to {value}.", ex);
                     }
                 }
             }
@@ -595,6 +604,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         public void StartExposure(CaptureSequence sequence) {
             if (_camera != null) {
                 SonyDriver driver = SonyDriver.GetInstance();
+
+                double exposureTime;
                 lock (_captureLock) {
                     _softCancelRequested = false;
                     if (!TryGetCaptureStatus(driver, out var captureStatus, "start exposure preflight") ||
@@ -610,18 +621,20 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                     }
 
                     if (BUSY_STATES.Contains(captureStatus)) {
-                        Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
-                        throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
+                        Notification.ShowWarning("Camera is still busy with a previous exposure; skipping new start.");
+                        throw new TaskCanceledException("Cannot start exposure: camera is still busy with a previous exposure.");
                     }
 
                     if (!IDLE_STATES.Contains(captureStatus)) {
-                        Logger.Warning($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
-                        throw new TaskCanceledException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
+                        Logger.Warning($"Cannot start exposure: camera in unexpected capture status ({captureStatus}).");
+                        throw new TaskCanceledException($"Cannot start exposure: camera in unexpected capture status ({captureStatus}).");
                     }
 
-                    double exposureTime = sequence.ExposureTime;
-                    driver.StartCapture(_camera.Handle, (float)exposureTime);
+                    exposureTime = sequence.ExposureTime;
                 }
+
+                // Start capture outside the capture lock to avoid blocking abort/cancel paths if the call hangs.
+                driver.StartCapture(_camera.Handle, (float)exposureTime);
             }
         }
 
@@ -651,8 +664,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                             throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
                         }
                     }
-                    Logger.Info(
-                        $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", COMPLETION_STATES)}");
+                    Logger.Info($"Waiting for image to be ready; current state is {captureStatus}; completion states are {String.Join(", ", COMPLETION_STATES)}.");
 
                     while (!COMPLETION_STATES.Contains(captureStatus)) {
                         await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), token);
@@ -664,7 +676,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                         }
                     }
 
-                    Logger.Info($"Wait for image ready complete, completion state is {captureStatus}");
+                    Logger.Info($"Wait for image ready complete; completion state is {captureStatus}.");
                     if (_softCancelRequested || token.IsCancellationRequested) {
                         _softCancelRequested = false;
                         throw new TaskCanceledException("Exposure cancelled by user (soft cancel).");
@@ -673,7 +685,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                     Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
                     throw;
                 } catch (Exception ex) {
-                    Logger.Error("WaitUntilExposureIsReady got exception", ex);
+                    Logger.Error("WaitUntilExposureIsReady got exception.", ex);
                     throw new SonyException("Problem while waiting for image to be ready (see log)");
                 }
             }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -111,7 +111,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             RaisePropertyChanged(nameof(Gains));
         }
 
-        private bool TryCancelCapture(string reason)
+        private bool TryCancelCaptureIfEnabled(string reason)
         {
             if (_camera == null)
             {
@@ -724,14 +724,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
                     if (BUSY_STATES.Contains(captureStatus))
                     {
-                        if (_enableNativeCancel)
+                        bool attemptedCancel = TryCancelCaptureIfEnabled("start exposure reset");
+                        if (attemptedCancel && !TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel"))
                         {
-                            TryCancelCapture("start exposure reset");
-                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel"))
-                            {
-                                Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
-                                throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
-                            }
+                            Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
+                            throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
                         }
                         if (BUSY_STATES.Contains(captureStatus))
                         {
@@ -772,19 +769,14 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public void AbortExposure()
         {
-            if (_enableNativeCancel)
+            if (TryCancelCaptureIfEnabled("abort request"))
             {
-                if (!TryCancelCapture("abort request"))
-                {
-                    Notification.ShowWarning("Abort requested, but the camera did not accept native cancel; exposure will continue until it finishes.");
-                }
+                return;
             }
-            else
-            {
-                _softCancelRequested = true;
-                Notification.ShowWarning("Abort requested; native cancel is disabled. Exposure will continue until it finishes.");
-                Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
-            }
+
+            _softCancelRequested = true;
+            Notification.ShowWarning("Abort requested; native cancel is disabled or the camera did not accept it. Exposure will continue until it finishes.");
+            Logger.Info("AbortExposure requested; native cancel unavailable; letting capture finish.");
         }
 
         public async Task WaitUntilExposureIsReady(CancellationToken token)

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -22,24 +22,27 @@ using NINA.Profile;
 using NINA.Profile.Interfaces;
 using Sony;
 
-namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
-    public class CameraDriver : BaseINPC, ICamera {
+namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
+{
+    public class CameraDriver : BaseINPC, ICamera
+    {
         // Some camera settings we are interested in
         private const uint PROPID_BATTERY = 53784;
         private const uint PROPID_ISO = 0xD21E; // Actual ISO currently set
         private const uint PROPID_ISOS = 0xFFFE; // Registry-backed list of learnt ISOs (may be empty until learnt)
 
         // Capture Status
-        private const uint CAPTURE_CREATED    = 0x0000;
-        private const uint CAPTURE_CAPTURING  = 0x0001;
-        private const uint CAPTURE_FAILED     = 0x0002;
-        private const uint CAPTURE_CANCELLED  = 0x0003;
-        private const uint CAPTURE_COMPLETE   = 0x0004;
-        private const uint CAPTURE_STARTING   = 0x8001;
-        private const uint CAPTURE_READING    = 0x8002;
+        private const uint CAPTURE_CREATED = 0x0000;
+        private const uint CAPTURE_CAPTURING = 0x0001;
+        private const uint CAPTURE_FAILED = 0x0002;
+        private const uint CAPTURE_CANCELLED = 0x0003;
+        private const uint CAPTURE_COMPLETE = 0x0004;
+        private const uint CAPTURE_STARTING = 0x8001;
+        private const uint CAPTURE_READING = 0x8002;
         private const uint CAPTURE_PROCESSING = 0x8003;
         private static readonly uint[] IDLE_STATES = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
         private static readonly uint[] BUSY_STATES = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
+        private static readonly uint[] COMPLETION_STATES = { CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
         private readonly bool _enableNativeCancel;
         private bool _softCancelRequested;
 
@@ -53,7 +56,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private AsyncObservableCollection<BinningMode> _binningModes;
         private readonly object _captureLock = new object();
 
-        public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, bool enableNativeCancel) {
+        public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, bool enableNativeCancel)
+        {
             _profileService = profileService;
             _exposureDataFactory = exposureDataFactory;
             _device = device;
@@ -63,24 +67,32 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         #region Internal Helpers
 
-        private PropertyValue GetPropertyValue(uint id) {
+        private PropertyValue GetPropertyValue(uint id)
+        {
             return SonyDriver.GetInstance().GetProperty(_camera.Handle, id);
         }
 
-        private IReadOnlyList<PropertyValueOption> GetAvailableIsoOptions() {
-            if (_camera == null) {
+        private IReadOnlyList<PropertyValueOption> GetAvailableIsoOptions()
+        {
+            if (_camera == null)
+            {
                 return Array.Empty<PropertyValueOption>();
             }
 
             uint[] propertyCandidates = { PROPID_ISOS, PROPID_ISO };
 
-            foreach (var propertyId in propertyCandidates) {
-                try {
+            foreach (var propertyId in propertyCandidates)
+            {
+                try
+                {
                     var options = _camera.GetPropertyInfo(propertyId)?.Options()?.Where(o => o.Value <= 0x00FFFFFF).ToList();
-                    if (options != null && options.Count > 0) {
+                    if (options != null && options.Count > 0)
+                    {
                         return options;
                     }
-                } catch (Exception ex) {
+                }
+                catch (Exception ex)
+                {
                     Logger.Warning($"Unable to enumerate ISO options for property 0x{propertyId:X}: {ex.Message}");
                 }
             }
@@ -89,7 +101,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             return Array.Empty<PropertyValueOption>();
         }
 
-        private void NotifyGainPropertiesChanged() {
+        private void NotifyGainPropertiesChanged()
+        {
             RaisePropertyChanged(nameof(CanGetGain));
             RaisePropertyChanged(nameof(CanSetGain));
             RaisePropertyChanged(nameof(GainMin));
@@ -98,24 +111,31 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             RaisePropertyChanged(nameof(Gains));
         }
 
-        private bool TryCancelCapture(string reason) {
-            if (_camera == null) {
+        private bool TryCancelCapture(string reason)
+        {
+            if (_camera == null)
+            {
                 return false;
             }
 
-            if (!_enableNativeCancel) {
+            if (!_enableNativeCancel)
+            {
                 Logger.Info($"Native cancel disabled; skipping cancel ({reason})");
                 return false;
             }
 
-            lock (_captureLock) {
-                try {
+            lock (_captureLock)
+            {
+                try
+                {
                     SonyDriver driver = SonyDriver.GetInstance();
-                    if (!TryGetCaptureStatusLocked(driver, out var status, reason)) {
+                    if (!TryGetCaptureStatusLocked(driver, out var status, reason))
+                    {
                         return false;
                     }
 
-                    if (!BUSY_STATES.Contains(status)) {
+                    if (!BUSY_STATES.Contains(status))
+                    {
                         Logger.Debug($"Skip cancel ({reason}); capture status is {status}");
                         return false;
                     }
@@ -123,18 +143,24 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                     Logger.Info($"Issuing cancel ({reason}); capture status is {status}");
                     driver.CancelCapture(_camera.Handle);
                     return true;
-                } catch (Exception ex) {
+                }
+                catch (Exception ex)
+                {
                     Logger.Error($"CancelCapture failed ({reason})", ex);
                     return false;
                 }
             }
         }
 
-        private bool TryGetCaptureStatusLocked(SonyDriver driver, out uint status, string reason) {
-            try {
+        private bool TryGetCaptureStatusLocked(SonyDriver driver, out uint status, string reason)
+        {
+            try
+            {
                 status = driver.GetCaptureStatus(_camera.Handle);
                 return true;
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 Logger.Warning($"Unable to get capture status ({reason}): {ex.Message}");
                 status = CAPTURE_FAILED;
                 return false;
@@ -150,7 +176,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         // Although the driver supports camera temperature, it gets it from the ARW's
         // metadata after a photo is taken, because this code doesn't request processed
         // ARW, the temp cannot be determined.
-        public double Temperature {
+        public double Temperature
+        {
             get => double.NaN;
             /*{
 
@@ -167,11 +194,16 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         public short BinX { get => 1; set => throw new NotImplementedException(); }
         public short BinY { get => 1; set => throw new NotImplementedException(); }
 
-        public string SensorName {
-            get {
-                if (_camera != null) {
+        public string SensorName
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return _camera.SensorName;
-                } else {
+                }
+                else
+                {
                     return string.Empty;
                 }
             }
@@ -183,42 +215,61 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public short BayerOffsetY { get => 1; set => throw new NotImplementedException(); }
 
-        public int CameraXSize {
-            get {
-                if (_camera != null) {
+        public int CameraXSize
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return _camera.ImageSize.Width;
                 }
-                else {
+                else
+                {
                     return 0;
                 }
             }
         }
 
-        public int CameraYSize {
-            get {
-                if (_camera != null) {
+        public int CameraYSize
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return _camera.ImageSize.Height;
-                } else {
+                }
+                else
+                {
                     return 0;
                 }
             }
         }
 
-        public double ExposureMin {
-            get {
-                if (_camera != null) {
+        public double ExposureMin
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return _camera.ExposureMin;
-                } else {
+                }
+                else
+                {
                     return double.NaN;
                 }
             }
         }
 
-        public double ExposureMax {
-            get {
-                if (_camera != null) {
+        public double ExposureMax
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return _camera.ExposureMax;
-                } else {
+                }
+                else
+                {
                     return double.NaN;
                 }
             }
@@ -228,21 +279,31 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public short MaxBinY { get => 1; set => throw new NotImplementedException(); }
 
-        public double PixelSizeX {
-            get {
-                if (_camera != null) {
+        public double PixelSizeX
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return _camera.PixelWidth;
-                } else {
+                }
+                else
+                {
                     return double.NaN;
                 }
             }
         }
 
-        public double PixelSizeY {
-            get {
-                if (_camera != null) {
+        public double PixelSizeY
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return _camera.PixelHeight;
-                } else {
+                }
+                else
+                {
                     return double.NaN;
                 }
             }
@@ -252,19 +313,26 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public CameraStates CameraState => CameraStates.NoState; // TODO
 
-        public bool CanShowLiveView {
-            get {
-                if (_camera != null) {
+        public bool CanShowLiveView
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return _camera.SupportsPreview();
-                } else {
+                }
+                else
+                {
                     return false;
                 }
             }
         }
 
-        public bool LiveViewEnabled {
+        public bool LiveViewEnabled
+        {
             get => _liveViewEnabled;
-            set {
+            set
+            {
                 _liveViewEnabled = value;
                 RaisePropertyChanged();
             }
@@ -272,21 +340,31 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public bool HasBattery => true;
 
-        public int BatteryLevel {
-            get {
-                if (_camera != null) {
+        public int BatteryLevel
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return (int)GetPropertyValue(PROPID_BATTERY).Value;
-                } else {
+                }
+                else
+                {
                     return 0;
                 }
             }
         }
 
-        public int BitDepth {
-            get {
-                if (_camera != null) {
+        public int BitDepth
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return _camera.BitsPerPixel;
-                } else {
+                }
+                else
+                {
                     return 0;
                 }
             }
@@ -296,11 +374,15 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public bool CanSetGain => CanGetGain;
 
-        public int GainMax {
-            get {
+        public int GainMax
+        {
+            get
+            {
                 var isoOptions = GetAvailableIsoOptions();
-                if (!isoOptions.Any()) {
-                    if (_camera != null) {
+                if (!isoOptions.Any())
+                {
+                    if (_camera != null)
+                    {
                         Logger.Error("Problem getting gain max: camera did not report ISO options.");
                     }
                     return -1;
@@ -310,11 +392,15 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             }
         }
 
-        public int GainMin {
-            get {
+        public int GainMin
+        {
+            get
+            {
                 var isoOptions = GetAvailableIsoOptions();
-                if (!isoOptions.Any()) {
-                    if (_camera != null) {
+                if (!isoOptions.Any())
+                {
+                    if (_camera != null)
+                    {
                         Logger.Error("Problem getting gain min: camera did not report ISO options.");
                     }
                     return -1;
@@ -324,42 +410,61 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             }
         }
 
-        public int Gain {
-            get {
-                if (_camera != null) {
-                    try {
+        public int Gain
+        {
+            get
+            {
+                if (_camera != null)
+                {
+                    try
+                    {
                         PropertyValue value = GetPropertyValue(PROPID_ISO);
 
                         return (int)(value.Value == 0xffffff ? 0 : value.Value);
-                    } catch (Exception ex) {
+                    }
+                    catch (Exception ex)
+                    {
                         Logger.Error("Problem getting gain", ex);
                         return -1;
                     }
-                } else {
+                }
+                else
+                {
                     return -1;
                 }
             }
 
-            set {
-                if (_camera != null) {
-                    try {
+            set
+            {
+                if (_camera != null)
+                {
+                    try
+                    {
                         SonyDriver.GetInstance().SetProperty(_camera.Handle, PROPID_ISO, (uint)value);
                         RaisePropertyChanged(nameof(Gain));
-                    } catch (Exception ex) {
+                    }
+                    catch (Exception ex)
+                    {
                         Logger.Error($"Problem setting gain to {value}", ex);
                     }
                 }
             }
         }
 
-        public IList<int> Gains {
-            get {
+        public IList<int> Gains
+        {
+            get
+            {
                 List<int> gains = new List<int>();
 
-                foreach (var iso in GetAvailableIsoOptions()) {
-                    if (iso.Value == 0xffffff) {
+                foreach (var iso in GetAvailableIsoOptions())
+                {
+                    if (iso.Value == 0xffffff)
+                    {
                         gains.Add(0); // AUTO
-                    } else {
+                    }
+                    else
+                    {
                         gains.Add((int)iso.Value);
                     }
                 }
@@ -370,29 +475,38 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public string Id => "Sony";
 
-        public string Name {
+        public string Name
+        {
             get => _device.Model;
             set => throw new NotImplementedException();
         }
 
-        public string DisplayName {
+        public string DisplayName
+        {
             get => _device.Model;
             set => throw new NotImplementedException();
         }
 
         public string Category { get => "Sony"; }
 
-        public bool Connected {
-            get {
+        public bool Connected
+        {
+            get
+            {
                 return _camera != null;
             }
         }
 
-        public string Description {
-            get {
-                if (_camera != null) {
+        public string Description
+        {
+            get
+            {
+                if (_camera != null)
+                {
                     return _camera.GetDescription();
-                } else {
+                }
+                else
+                {
                     return _device.GetDescription();
                 }
             }
@@ -402,10 +516,12 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public string DriverVersion => string.Empty;
 
-        public double TemperatureSetPoint {
+        public double TemperatureSetPoint
+        {
             get => double.NaN;
 
-            set {
+            set
+            {
             }
         }
 
@@ -421,9 +537,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public int SubSampleHeight { get; set; }
 
-        public bool CoolerOn {
+        public bool CoolerOn
+        {
             get => false;
-            set {
+            set
+            {
             }
         }
 
@@ -431,9 +549,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public bool HasDewHeater => false;
 
-        public bool DewHeaterOn {
+        public bool DewHeaterOn
+        {
             get => false;
-            set {
+            set
+            {
             }
         }
 
@@ -459,30 +579,38 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public IList<string> ReadoutModes => new List<string> { "Default" };
 
-        public short ReadoutMode {
+        public short ReadoutMode
+        {
             get => 0;
             set { }
         }
 
-        public short ReadoutModeForSnapImages {
+        public short ReadoutModeForSnapImages
+        {
             get => _readoutModeForSnapImages;
-            set {
+            set
+            {
                 _readoutModeForSnapImages = value;
                 RaisePropertyChanged();
             }
         }
 
-        public short ReadoutModeForNormalImages {
+        public short ReadoutModeForNormalImages
+        {
             get => _readoutModeForNormalImages;
-            set {
+            set
+            {
                 _readoutModeForNormalImages = value;
                 RaisePropertyChanged();
             }
         }
 
-        public AsyncObservableCollection<BinningMode> BinningModes {
-            get {
-                if (_binningModes == null) {
+        public AsyncObservableCollection<BinningMode> BinningModes
+        {
+            get
+            {
+                if (_binningModes == null)
+                {
                     _binningModes = new AsyncObservableCollection<BinningMode>();
                     _binningModes.Add(new BinningMode(1, 1));
                 }
@@ -495,19 +623,26 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         #region Supported Methods
 
-        public void StartLiveView(CaptureSequence sequence) {
+        public void StartLiveView(CaptureSequence sequence)
+        {
             LiveViewEnabled = true;
         }
 
-        public void StopLiveView() {
+        public void StopLiveView()
+        {
             LiveViewEnabled = false;
         }
 
-        public Task<bool> Connect(CancellationToken token) {
-            return Task.Run<bool>(() => {
-                try {
+        public Task<bool> Connect(CancellationToken token)
+        {
+            return Task.Run<bool>(() =>
+            {
+                try
+                {
                     _camera = SonyDriver.GetInstance().OpenCamera(_device.Id);
-                } catch (Exception ex) {
+                }
+                catch (Exception ex)
+                {
                     Logger.Error(ex);
                     _camera = null;
                 }
@@ -517,11 +652,16 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             });
         }
 
-        public void Disconnect() {
-            if (_camera != null) {
-                try {
+        public void Disconnect()
+        {
+            if (_camera != null)
+            {
+                try
+                {
                     SonyDriver.GetInstance().CloseCamera(_camera.Handle);
-                } catch (Exception ex) {
+                }
+                catch (Exception ex)
+                {
                     Logger.Error(ex);
                 }
 
@@ -530,9 +670,12 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             }
         }
 
-        public Task<IExposureData> DownloadLiveView(CancellationToken token) {
-            return Task.Run<IExposureData>(() => {
-                using (var memStream = new MemoryStream(SonyDriver.GetInstance().GetLiveView(_camera.Handle))) {
+        public Task<IExposureData> DownloadLiveView(CancellationToken token)
+        {
+            return Task.Run<IExposureData>(() =>
+            {
+                using (var memStream = new MemoryStream(SonyDriver.GetInstance().GetLiveView(_camera.Handle)))
+                {
                     memStream.Position = 0;
 
                     JpegBitmapDecoder decoder =
@@ -560,44 +703,58 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             });
         }
 
-        public void SetupDialog() {
+        public void SetupDialog()
+        {
             throw new NotImplementedException();
         }
 
-        public void StartExposure(CaptureSequence sequence) {
-            if (_camera != null) {
+        public void StartExposure(CaptureSequence sequence)
+        {
+            if (_camera != null)
+            {
                 SonyDriver driver = SonyDriver.GetInstance();
-                lock (_captureLock) {
+                lock (_captureLock)
+                {
                     _softCancelRequested = false;
-                    if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
+                    if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight"))
+                    {
                         Logger.Warning("Cannot start exposure: capture status unavailable.");
                         throw new TaskCanceledException("Cannot start exposure: capture status unavailable.");
                     }
 
-                    if (BUSY_STATES.Contains(captureStatus)) {
-                        if (_enableNativeCancel) {
+                    if (BUSY_STATES.Contains(captureStatus))
+                    {
+                        if (_enableNativeCancel)
+                        {
                             TryCancelCapture("start exposure reset");
-                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel")) {
+                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel"))
+                            {
                                 Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
                                 throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
                             }
                         }
-                        if (BUSY_STATES.Contains(captureStatus)) {
+                        if (BUSY_STATES.Contains(captureStatus))
+                        {
                             Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
                             throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
                         }
                     }
 
-                    if (!IDLE_STATES.Contains(captureStatus)) {
+                    if (!IDLE_STATES.Contains(captureStatus))
+                    {
                         Logger.Warning($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
                         throw new TaskCanceledException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
                     }
 
                     // Reset capture state for bodies that require a pre-start cancel, but only when native cancel is enabled.
-                    if (_enableNativeCancel) {
-                        try {
+                    if (_enableNativeCancel)
+                    {
+                        try
+                        {
                             driver.CancelCapture(_camera.Handle);
-                        } catch (Exception ex) {
+                        }
+                        catch (Exception ex)
+                        {
                             Logger.Warning($"Pre-start CancelCapture failed; continuing start. {ex.Message}");
                         }
                     }
@@ -608,66 +765,86 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             }
         }
 
-        public void StopExposure() {
+        public void StopExposure()
+        {
             AbortExposure();
         }
 
-        public void AbortExposure() {
-            if (_enableNativeCancel) {
+        public void AbortExposure()
+        {
+            if (_enableNativeCancel)
+            {
                 TryCancelCapture("abort request");
-            } else {
+            }
+            else
+            {
                 _softCancelRequested = true;
                 Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
             }
         }
 
-        public async Task WaitUntilExposureIsReady(CancellationToken token) {
-            using (token.Register(AbortExposure)) {
-                uint[] completionStates = { CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
+        public async Task WaitUntilExposureIsReady(CancellationToken token)
+        {
+            using (token.Register(AbortExposure))
+            {
 
                 SonyDriver driver = SonyDriver.GetInstance();
 
-                try {
+                try
+                {
                     uint captureStatus;
-                    lock (_captureLock) {
-                        if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait begin")) {
+                    lock (_captureLock)
+                    {
+                        if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait begin"))
+                        {
                             throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
                         }
                     }
                     Logger.Info(
-                        $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", completionStates)}");
+                        $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", COMPLETION_STATES)}");
 
-                    while (!completionStates.Contains(captureStatus)) {
+                    while (!COMPLETION_STATES.Contains(captureStatus))
+                    {
                         var waitToken = _enableNativeCancel ? token : CancellationToken.None;
                         await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), waitToken);
-                        if (!_enableNativeCancel && token.IsCancellationRequested) {
+                        if (!_enableNativeCancel && token.IsCancellationRequested)
+                        {
                             _softCancelRequested = true;
                         }
 
-                        lock (_captureLock) {
-                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll")) {
+                        lock (_captureLock)
+                        {
+                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll"))
+                            {
                                 throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
                             }
                         }
                     }
 
                     Logger.Info($"Wait for image ready complete, completion state is {captureStatus}");
-                    if (_softCancelRequested || token.IsCancellationRequested) {
+                    if (_softCancelRequested || token.IsCancellationRequested)
+                    {
                         _softCancelRequested = false;
                         throw new TaskCanceledException("Exposure cancelled by user (soft cancel).");
                     }
-                } catch (TaskCanceledException) {
+                }
+                catch (TaskCanceledException)
+                {
                     Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
                     throw;
-                } catch (Exception ex) {
+                }
+                catch (Exception ex)
+                {
                     Logger.Error("WaitUntilExposureIsReady got exception", ex);
                     throw new SonyException("Problem while waiting for image to be ready (see log)");
                 }
             }
         }
 
-        public Task<IExposureData> DownloadExposure(CancellationToken token) {
-            return Task.Run<IExposureData>(() => {
+        public Task<IExposureData> DownloadExposure(CancellationToken token)
+        {
+            return Task.Run<IExposureData>(() =>
+            {
                 byte[] rawImageData = SonyDriver.GetInstance().GetLastImage();
 
                 var metaData = new ImageMetaData();
@@ -684,29 +861,36 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         #region Unsupported Methods
 
-        public string Action(string actionName, string actionParameters) {
+        public string Action(string actionName, string actionParameters)
+        {
             throw new NotImplementedException();
         }
 
 
-        public void SendCommandBlind(string command, bool raw = true) {
+        public void SendCommandBlind(string command, bool raw = true)
+        {
             throw new NotImplementedException();
         }
 
-        public bool SendCommandBool(string command, bool raw = true) {
+        public bool SendCommandBool(string command, bool raw = true)
+        {
             throw new NotImplementedException();
         }
 
-        public string SendCommandString(string command, bool raw = true) {
+        public string SendCommandString(string command, bool raw = true)
+        {
             throw new NotImplementedException();
         }
 
-        public void SetBinning(short x, short y) {
+        public void SetBinning(short x, short y)
+        {
             // Ignore
         }
-        
-        public void UpdateSubSampleArea() {
-            if (_camera == null) {
+
+        public void UpdateSubSampleArea()
+        {
+            if (_camera == null)
+            {
                 EnableSubSample = false;
                 SubSampleX = 0;
                 SubSampleY = 0;
@@ -715,7 +899,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                 return;
             }
 
-            if (EnableSubSample && !CanSubSample) {
+            if (EnableSubSample && !CanSubSample)
+            {
                 Logger.Warning("Sub-sampling requested but not supported for Sony cameras. Falling back to full frame.");
                 EnableSubSample = false;
             }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -22,27 +22,26 @@ using NINA.Profile;
 using NINA.Profile.Interfaces;
 using Sony;
 
-namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
-{
-    public class CameraDriver : BaseINPC, ICamera
-    {
+namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
+    public class CameraDriver : BaseINPC, ICamera {
         // Some camera settings we are interested in
         private const uint PROPID_BATTERY = 53784;
         private const uint PROPID_ISO = 0xD21E; // Actual ISO currently set
         private const uint PROPID_ISOS = 0xFFFE; // Registry-backed list of learnt ISOs (may be empty until learnt)
 
         // Capture Status
-        private const uint CAPTURE_CREATED = 0x0000;
-        private const uint CAPTURE_CAPTURING = 0x0001;
-        private const uint CAPTURE_FAILED = 0x0002;
-        private const uint CAPTURE_CANCELLED = 0x0003;
-        private const uint CAPTURE_COMPLETE = 0x0004;
-        private const uint CAPTURE_STARTING = 0x8001;
-        private const uint CAPTURE_READING = 0x8002;
+        private const uint CAPTURE_CREATED    = 0x0000;
+        private const uint CAPTURE_CAPTURING  = 0x0001;
+        private const uint CAPTURE_FAILED     = 0x0002;
+        private const uint CAPTURE_CANCELLED  = 0x0003;
+        private const uint CAPTURE_COMPLETE   = 0x0004;
+        private const uint CAPTURE_STARTING   = 0x8001;
+        private const uint CAPTURE_READING    = 0x8002;
         private const uint CAPTURE_PROCESSING = 0x8003;
         private static readonly uint[] IDLE_STATES = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
         private static readonly uint[] BUSY_STATES = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
         private static readonly uint[] COMPLETION_STATES = { CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
+
         private readonly bool _enableNativeCancel;
         private bool _softCancelRequested;
 
@@ -56,8 +55,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
         private AsyncObservableCollection<BinningMode> _binningModes;
         private readonly object _captureLock = new object();
 
-        public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, bool enableNativeCancel)
-        {
+        public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, bool enableNativeCancel) {
             _profileService = profileService;
             _exposureDataFactory = exposureDataFactory;
             _device = device;
@@ -67,32 +65,24 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         #region Internal Helpers
 
-        private PropertyValue GetPropertyValue(uint id)
-        {
+        private PropertyValue GetPropertyValue(uint id) {
             return SonyDriver.GetInstance().GetProperty(_camera.Handle, id);
         }
 
-        private IReadOnlyList<PropertyValueOption> GetAvailableIsoOptions()
-        {
-            if (_camera == null)
-            {
+        private IReadOnlyList<PropertyValueOption> GetAvailableIsoOptions() {
+            if (_camera == null) {
                 return Array.Empty<PropertyValueOption>();
             }
 
             uint[] propertyCandidates = { PROPID_ISOS, PROPID_ISO };
 
-            foreach (var propertyId in propertyCandidates)
-            {
-                try
-                {
+            foreach (var propertyId in propertyCandidates) {
+                try {
                     var options = _camera.GetPropertyInfo(propertyId)?.Options()?.Where(o => o.Value <= 0x00FFFFFF).ToList();
-                    if (options != null && options.Count > 0)
-                    {
+                    if (options != null && options.Count > 0) {
                         return options;
                     }
-                }
-                catch (Exception ex)
-                {
+                } catch (Exception ex) {
                     Logger.Warning($"Unable to enumerate ISO options for property 0x{propertyId:X}: {ex.Message}");
                 }
             }
@@ -101,8 +91,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             return Array.Empty<PropertyValueOption>();
         }
 
-        private void NotifyGainPropertiesChanged()
-        {
+        private void NotifyGainPropertiesChanged() {
             RaisePropertyChanged(nameof(CanGetGain));
             RaisePropertyChanged(nameof(CanSetGain));
             RaisePropertyChanged(nameof(GainMin));
@@ -111,31 +100,24 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             RaisePropertyChanged(nameof(Gains));
         }
 
-        private bool TryCancelCaptureIfEnabled(string reason)
-        {
-            if (_camera == null)
-            {
+        private bool TryCancelCaptureIfEnabled(string reason) {
+            if (_camera == null) {
                 return false;
             }
 
-            if (!_enableNativeCancel)
-            {
+            if (!_enableNativeCancel) {
                 Logger.Info($"Native cancel disabled; skipping cancel ({reason})");
                 return false;
             }
 
-            lock (_captureLock)
-            {
-                try
-                {
+            lock (_captureLock) {
+                try {
                     SonyDriver driver = SonyDriver.GetInstance();
-                    if (!TryGetCaptureStatusLocked(driver, out var status, reason))
-                    {
+                    if (!TryGetCaptureStatusLocked(driver, out var status, reason)) {
                         return false;
                     }
 
-                    if (!BUSY_STATES.Contains(status))
-                    {
+                    if (!BUSY_STATES.Contains(status)) {
                         Logger.Debug($"Skip cancel ({reason}); capture status is {status}");
                         return false;
                     }
@@ -143,24 +125,18 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
                     Logger.Info($"Issuing cancel ({reason}); capture status is {status}");
                     driver.CancelCapture(_camera.Handle);
                     return true;
-                }
-                catch (Exception ex)
-                {
+                } catch (Exception ex) {
                     Logger.Error($"CancelCapture failed ({reason})", ex);
                     return false;
                 }
             }
         }
 
-        private bool TryGetCaptureStatusLocked(SonyDriver driver, out uint status, string reason)
-        {
-            try
-            {
+        private bool TryGetCaptureStatusLocked(SonyDriver driver, out uint status, string reason) {
+            try {
                 status = driver.GetCaptureStatus(_camera.Handle);
                 return true;
-            }
-            catch (Exception ex)
-            {
+            } catch (Exception ex) {
                 Logger.Warning($"Unable to get capture status ({reason}): {ex.Message}");
                 status = CAPTURE_FAILED;
                 return false;
@@ -176,8 +152,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
         // Although the driver supports camera temperature, it gets it from the ARW's
         // metadata after a photo is taken, because this code doesn't request processed
         // ARW, the temp cannot be determined.
-        public double Temperature
-        {
+        public double Temperature {
             get => double.NaN;
             /*{
 
@@ -194,16 +169,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
         public short BinX { get => 1; set => throw new NotImplementedException(); }
         public short BinY { get => 1; set => throw new NotImplementedException(); }
 
-        public string SensorName
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public string SensorName {
+            get {
+                if (_camera != null) {
                     return _camera.SensorName;
-                }
-                else
-                {
+                } else {
                     return string.Empty;
                 }
             }
@@ -215,61 +185,42 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public short BayerOffsetY { get => 1; set => throw new NotImplementedException(); }
 
-        public int CameraXSize
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public int CameraXSize {
+            get {
+                if (_camera != null) {
                     return _camera.ImageSize.Width;
                 }
-                else
-                {
+                else {
                     return 0;
                 }
             }
         }
 
-        public int CameraYSize
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public int CameraYSize {
+            get {
+                if (_camera != null) {
                     return _camera.ImageSize.Height;
-                }
-                else
-                {
+                } else {
                     return 0;
                 }
             }
         }
 
-        public double ExposureMin
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public double ExposureMin {
+            get {
+                if (_camera != null) {
                     return _camera.ExposureMin;
-                }
-                else
-                {
+                } else {
                     return double.NaN;
                 }
             }
         }
 
-        public double ExposureMax
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public double ExposureMax {
+            get {
+                if (_camera != null) {
                     return _camera.ExposureMax;
-                }
-                else
-                {
+                } else {
                     return double.NaN;
                 }
             }
@@ -279,31 +230,21 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public short MaxBinY { get => 1; set => throw new NotImplementedException(); }
 
-        public double PixelSizeX
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public double PixelSizeX {
+            get {
+                if (_camera != null) {
                     return _camera.PixelWidth;
-                }
-                else
-                {
+                } else {
                     return double.NaN;
                 }
             }
         }
 
-        public double PixelSizeY
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public double PixelSizeY {
+            get {
+                if (_camera != null) {
                     return _camera.PixelHeight;
-                }
-                else
-                {
+                } else {
                     return double.NaN;
                 }
             }
@@ -313,26 +254,19 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public CameraStates CameraState => CameraStates.NoState; // TODO
 
-        public bool CanShowLiveView
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public bool CanShowLiveView {
+            get {
+                if (_camera != null) {
                     return _camera.SupportsPreview();
-                }
-                else
-                {
+                } else {
                     return false;
                 }
             }
         }
 
-        public bool LiveViewEnabled
-        {
+        public bool LiveViewEnabled {
             get => _liveViewEnabled;
-            set
-            {
+            set {
                 _liveViewEnabled = value;
                 RaisePropertyChanged();
             }
@@ -340,31 +274,21 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public bool HasBattery => true;
 
-        public int BatteryLevel
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public int BatteryLevel {
+            get {
+                if (_camera != null) {
                     return (int)GetPropertyValue(PROPID_BATTERY).Value;
-                }
-                else
-                {
+                } else {
                     return 0;
                 }
             }
         }
 
-        public int BitDepth
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public int BitDepth {
+            get {
+                if (_camera != null) {
                     return _camera.BitsPerPixel;
-                }
-                else
-                {
+                } else {
                     return 0;
                 }
             }
@@ -374,15 +298,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public bool CanSetGain => CanGetGain;
 
-        public int GainMax
-        {
-            get
-            {
+        public int GainMax {
+            get {
                 var isoOptions = GetAvailableIsoOptions();
-                if (!isoOptions.Any())
-                {
-                    if (_camera != null)
-                    {
+                if (!isoOptions.Any()) {
+                    if (_camera != null) {
                         Logger.Error("Problem getting gain max: camera did not report ISO options.");
                     }
                     return -1;
@@ -392,15 +312,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             }
         }
 
-        public int GainMin
-        {
-            get
-            {
+        public int GainMin {
+            get {
                 var isoOptions = GetAvailableIsoOptions();
-                if (!isoOptions.Any())
-                {
-                    if (_camera != null)
-                    {
+                if (!isoOptions.Any()) {
+                    if (_camera != null) {
                         Logger.Error("Problem getting gain min: camera did not report ISO options.");
                     }
                     return -1;
@@ -410,61 +326,42 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             }
         }
 
-        public int Gain
-        {
-            get
-            {
-                if (_camera != null)
-                {
-                    try
-                    {
+        public int Gain {
+            get {
+                if (_camera != null) {
+                    try {
                         PropertyValue value = GetPropertyValue(PROPID_ISO);
 
                         return (int)(value.Value == 0xffffff ? 0 : value.Value);
-                    }
-                    catch (Exception ex)
-                    {
+                    } catch (Exception ex) {
                         Logger.Error("Problem getting gain", ex);
                         return -1;
                     }
-                }
-                else
-                {
+                } else {
                     return -1;
                 }
             }
 
-            set
-            {
-                if (_camera != null)
-                {
-                    try
-                    {
+            set {
+                if (_camera != null) {
+                    try {
                         SonyDriver.GetInstance().SetProperty(_camera.Handle, PROPID_ISO, (uint)value);
                         RaisePropertyChanged(nameof(Gain));
-                    }
-                    catch (Exception ex)
-                    {
+                    } catch (Exception ex) {
                         Logger.Error($"Problem setting gain to {value}", ex);
                     }
                 }
             }
         }
 
-        public IList<int> Gains
-        {
-            get
-            {
+        public IList<int> Gains {
+            get {
                 List<int> gains = new List<int>();
 
-                foreach (var iso in GetAvailableIsoOptions())
-                {
-                    if (iso.Value == 0xffffff)
-                    {
+                foreach (var iso in GetAvailableIsoOptions()) {
+                    if (iso.Value == 0xffffff) {
                         gains.Add(0); // AUTO
-                    }
-                    else
-                    {
+                    } else {
                         gains.Add((int)iso.Value);
                     }
                 }
@@ -475,38 +372,29 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public string Id => "Sony";
 
-        public string Name
-        {
+        public string Name {
             get => _device.Model;
             set => throw new NotImplementedException();
         }
 
-        public string DisplayName
-        {
+        public string DisplayName {
             get => _device.Model;
             set => throw new NotImplementedException();
         }
 
         public string Category { get => "Sony"; }
 
-        public bool Connected
-        {
-            get
-            {
+        public bool Connected {
+            get {
                 return _camera != null;
             }
         }
 
-        public string Description
-        {
-            get
-            {
-                if (_camera != null)
-                {
+        public string Description {
+            get {
+                if (_camera != null) {
                     return _camera.GetDescription();
-                }
-                else
-                {
+                } else {
                     return _device.GetDescription();
                 }
             }
@@ -516,12 +404,10 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public string DriverVersion => string.Empty;
 
-        public double TemperatureSetPoint
-        {
+        public double TemperatureSetPoint {
             get => double.NaN;
 
-            set
-            {
+            set {
             }
         }
 
@@ -537,11 +423,9 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public int SubSampleHeight { get; set; }
 
-        public bool CoolerOn
-        {
+        public bool CoolerOn {
             get => false;
-            set
-            {
+            set {
             }
         }
 
@@ -549,11 +433,9 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public bool HasDewHeater => false;
 
-        public bool DewHeaterOn
-        {
+        public bool DewHeaterOn {
             get => false;
-            set
-            {
+            set {
             }
         }
 
@@ -579,38 +461,30 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         public IList<string> ReadoutModes => new List<string> { "Default" };
 
-        public short ReadoutMode
-        {
+        public short ReadoutMode {
             get => 0;
             set { }
         }
 
-        public short ReadoutModeForSnapImages
-        {
+        public short ReadoutModeForSnapImages {
             get => _readoutModeForSnapImages;
-            set
-            {
+            set {
                 _readoutModeForSnapImages = value;
                 RaisePropertyChanged();
             }
         }
 
-        public short ReadoutModeForNormalImages
-        {
+        public short ReadoutModeForNormalImages {
             get => _readoutModeForNormalImages;
-            set
-            {
+            set {
                 _readoutModeForNormalImages = value;
                 RaisePropertyChanged();
             }
         }
 
-        public AsyncObservableCollection<BinningMode> BinningModes
-        {
-            get
-            {
-                if (_binningModes == null)
-                {
+        public AsyncObservableCollection<BinningMode> BinningModes {
+            get {
+                if (_binningModes == null) {
                     _binningModes = new AsyncObservableCollection<BinningMode>();
                     _binningModes.Add(new BinningMode(1, 1));
                 }
@@ -623,26 +497,19 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         #region Supported Methods
 
-        public void StartLiveView(CaptureSequence sequence)
-        {
+        public void StartLiveView(CaptureSequence sequence) {
             LiveViewEnabled = true;
         }
 
-        public void StopLiveView()
-        {
+        public void StopLiveView() {
             LiveViewEnabled = false;
         }
 
-        public Task<bool> Connect(CancellationToken token)
-        {
-            return Task.Run<bool>(() =>
-            {
-                try
-                {
+        public Task<bool> Connect(CancellationToken token) {
+            return Task.Run<bool>(() => {
+                try {
                     _camera = SonyDriver.GetInstance().OpenCamera(_device.Id);
-                }
-                catch (Exception ex)
-                {
+                } catch (Exception ex) {
                     Logger.Error(ex);
                     _camera = null;
                 }
@@ -652,16 +519,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             });
         }
 
-        public void Disconnect()
-        {
-            if (_camera != null)
-            {
-                try
-                {
+        public void Disconnect() {
+            if (_camera != null) {
+                try {
                     SonyDriver.GetInstance().CloseCamera(_camera.Handle);
-                }
-                catch (Exception ex)
-                {
+                } catch (Exception ex) {
                     Logger.Error(ex);
                 }
 
@@ -670,12 +532,9 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             }
         }
 
-        public Task<IExposureData> DownloadLiveView(CancellationToken token)
-        {
-            return Task.Run<IExposureData>(() =>
-            {
-                using (var memStream = new MemoryStream(SonyDriver.GetInstance().GetLiveView(_camera.Handle)))
-                {
+        public Task<IExposureData> DownloadLiveView(CancellationToken token) {
+            return Task.Run<IExposureData>(() => {
+                using (var memStream = new MemoryStream(SonyDriver.GetInstance().GetLiveView(_camera.Handle))) {
                     memStream.Position = 0;
 
                     JpegBitmapDecoder decoder =
@@ -703,42 +562,33 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             });
         }
 
-        public void SetupDialog()
-        {
+        public void SetupDialog() {
             throw new NotImplementedException();
         }
 
-        public void StartExposure(CaptureSequence sequence)
-        {
-            if (_camera != null)
-            {
+        public void StartExposure(CaptureSequence sequence) {
+            if (_camera != null) {
                 SonyDriver driver = SonyDriver.GetInstance();
-                lock (_captureLock)
-                {
+                lock (_captureLock) {
                     _softCancelRequested = false;
-                    if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight"))
-                    {
+                    if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
                         Logger.Warning("Cannot start exposure: capture status unavailable.");
                         throw new TaskCanceledException("Cannot start exposure: capture status unavailable.");
                     }
 
-                    if (BUSY_STATES.Contains(captureStatus))
-                    {
+                    if (BUSY_STATES.Contains(captureStatus)) {
                         TryCancelCaptureIfEnabled("start exposure reset");
-                        if (_enableNativeCancel && !TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel"))
-                        {
+                        if (_enableNativeCancel && !TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel")) {
                             Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
                             throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
                         }
-                        if (BUSY_STATES.Contains(captureStatus))
-                        {
+                        if (BUSY_STATES.Contains(captureStatus)) {
                             Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
                             throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
                         }
                     }
 
-                    if (!IDLE_STATES.Contains(captureStatus))
-                    {
+                    if (!IDLE_STATES.Contains(captureStatus)) {
                         Logger.Warning($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
                         throw new TaskCanceledException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
                     }
@@ -752,15 +602,12 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             }
         }
 
-        public void StopExposure()
-        {
+        public void StopExposure() {
             AbortExposure();
         }
 
-        public void AbortExposure()
-        {
-            if (TryCancelCaptureIfEnabled("abort request"))
-            {
+        public void AbortExposure() {
+            if (TryCancelCaptureIfEnabled("abort request")) {
                 return;
             }
 
@@ -769,68 +616,52 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
             Logger.Info("AbortExposure requested; native cancel unavailable; letting capture finish.");
         }
 
-        public async Task WaitUntilExposureIsReady(CancellationToken token)
-        {
-            using (token.Register(AbortExposure))
-            {
+        public async Task WaitUntilExposureIsReady(CancellationToken token) {
+            using (token.Register(AbortExposure)) {
 
                 SonyDriver driver = SonyDriver.GetInstance();
 
-                try
-                {
+                try {
                     uint captureStatus;
-                    lock (_captureLock)
-                    {
-                        if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait begin"))
-                        {
+                    lock (_captureLock) {
+                        if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait begin")) {
                             throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
                         }
                     }
                     Logger.Info(
                         $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", COMPLETION_STATES)}");
 
-                    while (!COMPLETION_STATES.Contains(captureStatus))
-                    {
+                    while (!COMPLETION_STATES.Contains(captureStatus)) {
                         var waitToken = _enableNativeCancel ? token : CancellationToken.None;
                         await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), waitToken);
-                        if (!_enableNativeCancel && token.IsCancellationRequested)
-                        {
+                        if (!_enableNativeCancel && token.IsCancellationRequested) {
                             _softCancelRequested = true;
                         }
 
-                        lock (_captureLock)
-                        {
-                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll"))
-                            {
+                        lock (_captureLock) {
+                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll")) {
                                 throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
                             }
                         }
                     }
 
                     Logger.Info($"Wait for image ready complete, completion state is {captureStatus}");
-                    if (_softCancelRequested || token.IsCancellationRequested)
-                    {
+                    if (_softCancelRequested || token.IsCancellationRequested) {
                         _softCancelRequested = false;
                         throw new TaskCanceledException("Exposure cancelled by user (soft cancel).");
                     }
-                }
-                catch (TaskCanceledException)
-                {
+                } catch (TaskCanceledException) {
                     Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
                     throw;
-                }
-                catch (Exception ex)
-                {
+                } catch (Exception ex) {
                     Logger.Error("WaitUntilExposureIsReady got exception", ex);
                     throw new SonyException("Problem while waiting for image to be ready (see log)");
                 }
             }
         }
 
-        public Task<IExposureData> DownloadExposure(CancellationToken token)
-        {
-            return Task.Run<IExposureData>(() =>
-            {
+        public Task<IExposureData> DownloadExposure(CancellationToken token) {
+            return Task.Run<IExposureData>(() => {
                 byte[] rawImageData = SonyDriver.GetInstance().GetLastImage();
 
                 var metaData = new ImageMetaData();
@@ -847,36 +678,29 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
         #region Unsupported Methods
 
-        public string Action(string actionName, string actionParameters)
-        {
+        public string Action(string actionName, string actionParameters) {
             throw new NotImplementedException();
         }
 
 
-        public void SendCommandBlind(string command, bool raw = true)
-        {
+        public void SendCommandBlind(string command, bool raw = true) {
             throw new NotImplementedException();
         }
 
-        public bool SendCommandBool(string command, bool raw = true)
-        {
+        public bool SendCommandBool(string command, bool raw = true) {
             throw new NotImplementedException();
         }
 
-        public string SendCommandString(string command, bool raw = true)
-        {
+        public string SendCommandString(string command, bool raw = true) {
             throw new NotImplementedException();
         }
 
-        public void SetBinning(short x, short y)
-        {
+        public void SetBinning(short x, short y) {
             // Ignore
         }
-
-        public void UpdateSubSampleArea()
-        {
-            if (_camera == null)
-            {
+        
+        public void UpdateSubSampleArea() {
+            if (_camera == null) {
                 EnableSubSample = false;
                 SubSampleX = 0;
                 SubSampleY = 0;
@@ -885,8 +709,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
                 return;
             }
 
-            if (EnableSubSample && !CanSubSample)
-            {
+            if (EnableSubSample && !CanSubSample) {
                 Logger.Warning("Sub-sampling requested but not supported for Sony cameras. Falling back to full frame.");
                 EnableSubSample = false;
             }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -47,6 +47,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private readonly PluginOptionsAccessor _pluginSettings;
         private readonly bool _enableNativeCancelDefault;
         private bool _softCancelRequested;
+        private bool _abortWarningShown;
 
         private SonyCameraInfo _camera = null;
         private SonyDevice _device = null;
@@ -65,6 +66,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             _pluginSettings = pluginSettings;
             _enableNativeCancelDefault = enableNativeCancel;
             _softCancelRequested = false;
+            _abortWarningShown = false;
         }
 
         #region Internal Helpers
@@ -608,6 +610,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                 double exposureTime;
                 lock (_captureLock) {
                     _softCancelRequested = false;
+                    _abortWarningShown = false;
                     if (!TryGetCaptureStatus(driver, out var captureStatus, "start exposure preflight") ||
                         captureStatus == CAPTURE_STATUS_UNKNOWN) {
                         Logger.Warning("Cannot start exposure: capture status unavailable.");
@@ -648,7 +651,10 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             }
 
             _softCancelRequested = true;
-            Notification.ShowWarning("Abort requested; native cancel is disabled or the camera did not accept it. Exposure will continue until it finishes.");
+            if (!_abortWarningShown) {
+                Notification.ShowWarning("Abort requested; native cancel is disabled or the camera did not accept it. Exposure will continue until it finishes.");
+                _abortWarningShown = true;
+            }
             Logger.Info("AbortExposure requested; native cancel unavailable; letting capture finish.");
         }
 

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -40,7 +40,6 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private const uint CAPTURE_PROCESSING = 0x8003;
         private static readonly uint[] IDLE_STATES = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
         private static readonly uint[] BUSY_STATES = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
-        private static readonly uint[] CANCELLABLE_STATES = BUSY_STATES;
         private readonly bool _enableNativeCancel;
         private bool _softCancelRequested;
 
@@ -116,7 +115,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                         return false;
                     }
 
-                    if (!CANCELLABLE_STATES.Contains(status)) {
+                    if (!BUSY_STATES.Contains(status)) {
                         Logger.Debug($"Skip cancel ({reason}); capture status is {status}");
                         return false;
                     }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -569,6 +569,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             if (_camera != null) {
                 SonyDriver driver = SonyDriver.GetInstance();
                 lock (_captureLock) {
+                    bool issuedCancel = false;
                     _softCancelRequested = false;
                     if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
                         Logger.Warning("Cannot start exposure: capture status unavailable.");
@@ -577,15 +578,37 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
                     if (BUSY_STATES.Contains(captureStatus)) {
                         if (_enableNativeCancel) {
-                            TryCancelCapture("start exposure reset");
+                            try {
+                                Logger.Info($"Cancelling existing capture before starting new one; status {captureStatus}");
+                                driver.CancelCapture(_camera.Handle);
+                                issuedCancel = true;
+                                if (!TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel")) {
+                                    Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
+                                    throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
+                                }
+                            } catch (Exception ex) {
+                                Logger.Error("CancelCapture failed before start", ex);
+                            }
                         }
-                        Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
-                        throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
+                        if (BUSY_STATES.Contains(captureStatus)) {
+                            Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
+                            throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
+                        }
                     }
 
                     if (!IDLE_STATES.Contains(captureStatus)) {
                         Logger.Warning($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
                         throw new TaskCanceledException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
+                    }
+
+                    // Reset capture state for bodies that require a pre-start cancel, but only when native cancel is enabled.
+                    if (_enableNativeCancel && !issuedCancel) {
+                        try {
+                            driver.CancelCapture(_camera.Handle);
+                            issuedCancel = true;
+                        } catch (Exception ex) {
+                            Logger.Warning($"Pre-start CancelCapture failed; continuing start. {ex.Message}");
+                        }
                     }
 
                     double exposureTime = sequence.ExposureTime;
@@ -624,7 +647,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                         $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", completionStates)}");
 
                     while (!completionStates.Contains(captureStatus)) {
-                        await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), token);
+                        var waitToken = _enableNativeCancel ? token : CancellationToken.None;
+                        await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), waitToken);
                         if (!_enableNativeCancel && token.IsCancellationRequested) {
                             _softCancelRequested = true;
                         }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -583,25 +583,21 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                         throw new TaskCanceledException("Cannot start exposure: capture status unavailable.");
                     }
 
+                    TryCancelCaptureIfEnabled("start exposure reset");
+                    if (_enableNativeCancel && (!TryGetCaptureStatus(driver, out captureStatus, "start exposure post-cancel") || captureStatus == CAPTURE_STATUS_UNKNOWN)) {
+                        Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
+                        throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
+                    }
+
                     if (BUSY_STATES.Contains(captureStatus)) {
-                        TryCancelCaptureIfEnabled("start exposure reset");
-                        if (_enableNativeCancel && (!TryGetCaptureStatus(driver, out captureStatus, "start exposure post-cancel") || captureStatus == CAPTURE_STATUS_UNKNOWN)) {
-                            Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
-                            throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
-                        }
-                        if (BUSY_STATES.Contains(captureStatus)) {
-                            Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
-                            throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
-                        }
+                        Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
+                        throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
                     }
 
                     if (!IDLE_STATES.Contains(captureStatus)) {
                         Logger.Warning($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
                         throw new TaskCanceledException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
                     }
-
-                    // Reset capture state for bodies that require a pre-start cancel, but only when native cancel is enabled.
-                    TryCancelCaptureIfEnabled("start exposure pre-start reset");
 
                     double exposureTime = sequence.ExposureTime;
                     driver.StartCapture(_camera.Handle, (float)exposureTime);
@@ -639,11 +635,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                         $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", COMPLETION_STATES)}");
 
                     while (!COMPLETION_STATES.Contains(captureStatus)) {
-                        var waitToken = _enableNativeCancel ? token : CancellationToken.None;
-                        await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), waitToken);
-                        if (!_enableNativeCancel && token.IsCancellationRequested) {
-                            _softCancelRequested = true;
-                        }
+                        await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), token);
 
                         lock (_captureLock) {
                             if (!TryGetCaptureStatus(driver, out captureStatus, "wait poll") || captureStatus == CAPTURE_STATUS_UNKNOWN) {

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -724,8 +724,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers
 
                     if (BUSY_STATES.Contains(captureStatus))
                     {
-                        bool attemptedCancel = TryCancelCaptureIfEnabled("start exposure reset");
-                        if (attemptedCancel && !TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel"))
+                        TryCancelCaptureIfEnabled("start exposure reset");
+                        if (_enableNativeCancel && !TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel"))
                         {
                             Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
                             throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -1,724 +1,863 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Windows.Media.Imaging;
-using FTD2XX_NET;
-using NINA.Core.Enum;
-using NINA.Core.Model.Equipment;
-using NINA.Core.Utility;
-using NINA.Core.Utility.Notification;
-using NINA.Equipment.Interfaces;
-using NINA.Equipment.Interfaces.Mediator;
-using NINA.Equipment.Model;
-using NINA.Equipment.SDK.CameraSDKs.ASTPANSDK;
-using NINA.Equipment.Utility;
-using NINA.Image.ImageData;
-using NINA.Image.Interfaces;
-using NINA.Profile;
-using NINA.Profile.Interfaces;
-using Sony;
+﻿namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers;
 
-namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
-    public class CameraDriver : BaseINPC, ICamera {
-        // Some camera settings we are interested in
-        private const uint PROPID_BATTERY = 53784;
-        private const uint PROPID_ISO = 0xD21E; // Actual ISO currently set
-        private const uint PROPID_ISOS = 0xFFFE; // Registry-backed list of learnt ISOs (may be empty until learnt)
+public class CameraDriver : BaseINPC, ICamera
+{
+    #region constants
+    private const uint CAPTURE_CANCELLED = 0x0003;
+    private const uint CAPTURE_CAPTURING = 0x0001;
+    private const uint CAPTURE_COMPLETE = 0x0004;
 
-        // Capture Status
-        private const uint CAPTURE_CREATED    = 0x0000;
-        private const uint CAPTURE_CAPTURING  = 0x0001;
-        private const uint CAPTURE_FAILED     = 0x0002;
-        private const uint CAPTURE_CANCELLED  = 0x0003;
-        private const uint CAPTURE_COMPLETE   = 0x0004;
-        private const uint CAPTURE_STARTING   = 0x8001;
-        private const uint CAPTURE_READING    = 0x8002;
-        private const uint CAPTURE_PROCESSING = 0x8003;
-        private static readonly uint[] IDLE_STATES = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
-        private static readonly uint[] BUSY_STATES = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
-        private readonly bool _enableNativeCancel;
-        private bool _softCancelRequested;
+    // Registry-backed list of learnt ISOs (may be empty until learnt)
 
-        private SonyCameraInfo _camera = null;
-        private SonyDevice _device = null;
-        private IProfileService _profileService;
-        private readonly IExposureDataFactory _exposureDataFactory;
-        private bool _liveViewEnabled;
-        private short _readoutModeForSnapImages;
-        private short _readoutModeForNormalImages;
-        private AsyncObservableCollection<BinningMode> _binningModes;
-        private readonly object _captureLock = new object();
+    // Capture Status
+    private const uint CAPTURE_CREATED = 0x0000;
 
-        public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, bool enableNativeCancel) {
-            _profileService = profileService;
-            _exposureDataFactory = exposureDataFactory;
-            _device = device;
-            _enableNativeCancel = enableNativeCancel;
-            _softCancelRequested = false;
-        }
+    private const uint CAPTURE_FAILED = 0x0002;
+    private const uint CAPTURE_PROCESSING = 0x8003;
+    private const uint CAPTURE_READING = 0x8002;
+    private const uint CAPTURE_STARTING = 0x8001;
 
-        #region Internal Helpers
+    // Some camera settings we are interested in
+    private const uint PROPID_BATTERY = 53784;
 
-        private PropertyValue GetPropertyValue(uint id) {
-            return SonyDriver.GetInstance().GetProperty(_camera.Handle, id);
-        }
+    private const uint PROPID_ISO = 0xD21E;
 
-        private IReadOnlyList<PropertyValueOption> GetAvailableIsoOptions() {
-            if (_camera == null) {
-                return Array.Empty<PropertyValueOption>();
+    // Actual ISO currently set
+    private const uint PROPID_ISOS = 0xFFFE;
+
+    #endregion
+
+    #region properties
+
+    public int BatteryLevel
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return (int)GetPropertyValue(PROPID_BATTERY).Value;
             }
-
-            uint[] propertyCandidates = { PROPID_ISOS, PROPID_ISO };
-
-            foreach (var propertyId in propertyCandidates) {
-                try {
-                    var options = _camera.GetPropertyInfo(propertyId)?.Options()?.Where(o => o.Value <= 0x00FFFFFF).ToList();
-                    if (options != null && options.Count > 0) {
-                        return options;
-                    }
-                } catch (Exception ex) {
-                    Logger.Warning($"Unable to enumerate ISO options for property 0x{propertyId:X}: {ex.Message}");
-                }
-            }
-
-            Logger.Warning("Camera did not report any ISO options via known properties (registry ISO list may be empty until the camera learns it).");
-            return Array.Empty<PropertyValueOption>();
-        }
-
-        private void NotifyGainPropertiesChanged() {
-            RaisePropertyChanged(nameof(CanGetGain));
-            RaisePropertyChanged(nameof(CanSetGain));
-            RaisePropertyChanged(nameof(GainMin));
-            RaisePropertyChanged(nameof(GainMax));
-            RaisePropertyChanged(nameof(Gain));
-            RaisePropertyChanged(nameof(Gains));
-        }
-
-        private bool TryCancelCapture(string reason) {
-            if (_camera == null) {
-                return false;
-            }
-
-            if (!_enableNativeCancel) {
-                Logger.Info($"Native cancel disabled; skipping cancel ({reason})");
-                return false;
-            }
-
-            lock (_captureLock) {
-                try {
-                    SonyDriver driver = SonyDriver.GetInstance();
-                    if (!TryGetCaptureStatusLocked(driver, out var status, reason)) {
-                        return false;
-                    }
-
-                    if (!BUSY_STATES.Contains(status)) {
-                        Logger.Debug($"Skip cancel ({reason}); capture status is {status}");
-                        return false;
-                    }
-
-                    Logger.Info($"Issuing cancel ({reason}); capture status is {status}");
-                    driver.CancelCapture(_camera.Handle);
-                    return true;
-                } catch (Exception ex) {
-                    Logger.Error($"CancelCapture failed ({reason})", ex);
-                    return false;
-                }
+            else
+            {
+                return 0;
             }
         }
+    }
 
-        private bool TryGetCaptureStatusLocked(SonyDriver driver, out uint status, string reason) {
-            try {
-                status = driver.GetCaptureStatus(_camera.Handle);
-                return true;
-            } catch (Exception ex) {
-                Logger.Warning($"Unable to get capture status ({reason}): {ex.Message}");
-                status = CAPTURE_FAILED;
+    public short BayerOffsetX { get => 1; set => throw new NotImplementedException(); }
+    public short BayerOffsetY { get => 1; set => throw new NotImplementedException(); }
+
+    public AsyncObservableCollection<BinningMode> BinningModes
+    {
+        get
+        {
+            if (_binningModes == null)
+            {
+                _binningModes = new AsyncObservableCollection<BinningMode>();
+                _binningModes.Add(new BinningMode(1, 1));
+            }
+
+            return _binningModes;
+        }
+    }
+
+    public short BinX { get => 1; set => throw new NotImplementedException(); }
+    public short BinY { get => 1; set => throw new NotImplementedException(); }
+
+    public int BitDepth
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return _camera.BitsPerPixel;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    }
+
+    public CameraStates CameraState => CameraStates.NoState;
+
+    public int CameraXSize
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return _camera.ImageSize.Width;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    }
+
+    public int CameraYSize
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return _camera.ImageSize.Height;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    }
+
+    public bool CanGetGain => GetAvailableIsoOptions().Any();
+    public bool CanSetGain => CanGetGain;
+    public bool CanSetOffset => false;
+    public bool CanSetTemperature => false;
+    public bool CanSetUSBLimit => false;
+
+    // TODO
+
+    public bool CanShowLiveView
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return _camera.SupportsPreview();
+            }
+            else
+            {
                 return false;
             }
         }
+    }
 
-        #endregion
+    public bool CanSubSample => false;
+    public string Category { get => "Sony"; }
 
-        #region Supported Properties
-
-        public bool HasShutter => true;
-
-        // Although the driver supports camera temperature, it gets it from the ARW's
-        // metadata after a photo is taken, because this code doesn't request processed
-        // ARW, the temp cannot be determined.
-        public double Temperature {
-            get => double.NaN;
-            /*{
-
-                if (_camera != null) {
-                    PropertyValue value = GetPropertyValue(PROPID_TEMPERATURE);
-
-                    return (value.Value) / 10.0;
-                } else {
-                    return double.NaN;
-                }
-            }*/
+    public bool Connected
+    {
+        get
+        {
+            return _camera != null;
         }
+    }
 
-        public short BinX { get => 1; set => throw new NotImplementedException(); }
-        public short BinY { get => 1; set => throw new NotImplementedException(); }
+    public bool CoolerOn
+    {
+        get => false;
+        set
+        {
+        }
+    }
 
-        public string SensorName {
-            get {
-                if (_camera != null) {
-                    return _camera.SensorName;
-                } else {
-                    return string.Empty;
-                }
+    public double CoolerPower => double.NaN;
+
+    public string Description
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return _camera.GetDescription();
+            }
+            else
+            {
+                return _device.GetDescription();
             }
         }
+    }
 
-        public SensorType SensorType { get => SensorType.RGGB; set => throw new NotImplementedException(); }
+    public bool DewHeaterOn
+    {
+        get => false;
+        set
+        {
+        }
+    }
 
-        public short BayerOffsetX { get => 1; set => throw new NotImplementedException(); }
+    public string DisplayName
+    {
+        get => _device.Model;
+        set => throw new NotImplementedException();
+    }
 
-        public short BayerOffsetY { get => 1; set => throw new NotImplementedException(); }
+    public string DriverInfo => "https://retro.kiwi";
+    public string DriverVersion => string.Empty;
+    public double ElectronsPerADU => double.NaN;
+    public bool EnableSubSample { get; set; }
 
-        public int CameraXSize {
-            get {
-                if (_camera != null) {
-                    return _camera.ImageSize.Width;
-                }
-                else {
-                    return 0;
-                }
+    public double ExposureMax
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return _camera.ExposureMax;
+            }
+            else
+            {
+                return double.NaN;
             }
         }
+    }
 
-        public int CameraYSize {
-            get {
-                if (_camera != null) {
-                    return _camera.ImageSize.Height;
-                } else {
-                    return 0;
+    public double ExposureMin
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return _camera.ExposureMin;
+            }
+            else
+            {
+                return double.NaN;
+            }
+        }
+    }
+
+    public int Gain
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                try
+                {
+                    PropertyValue value = GetPropertyValue(PROPID_ISO);
+
+                    return (int)(value.Value == 0xffffff ? 0 : value.Value);
                 }
-            }
-        }
-
-        public double ExposureMin {
-            get {
-                if (_camera != null) {
-                    return _camera.ExposureMin;
-                } else {
-                    return double.NaN;
-                }
-            }
-        }
-
-        public double ExposureMax {
-            get {
-                if (_camera != null) {
-                    return _camera.ExposureMax;
-                } else {
-                    return double.NaN;
-                }
-            }
-        }
-
-        public short MaxBinX { get => 1; set => throw new NotImplementedException(); }
-
-        public short MaxBinY { get => 1; set => throw new NotImplementedException(); }
-
-        public double PixelSizeX {
-            get {
-                if (_camera != null) {
-                    return _camera.PixelWidth;
-                } else {
-                    return double.NaN;
-                }
-            }
-        }
-
-        public double PixelSizeY {
-            get {
-                if (_camera != null) {
-                    return _camera.PixelHeight;
-                } else {
-                    return double.NaN;
-                }
-            }
-        }
-
-        public bool CanSetTemperature => false;
-
-        public CameraStates CameraState => CameraStates.NoState; // TODO
-
-        public bool CanShowLiveView {
-            get {
-                if (_camera != null) {
-                    return _camera.SupportsPreview();
-                } else {
-                    return false;
-                }
-            }
-        }
-
-        public bool LiveViewEnabled {
-            get => _liveViewEnabled;
-            set {
-                _liveViewEnabled = value;
-                RaisePropertyChanged();
-            }
-        }
-
-        public bool HasBattery => true;
-
-        public int BatteryLevel {
-            get {
-                if (_camera != null) {
-                    return (int)GetPropertyValue(PROPID_BATTERY).Value;
-                } else {
-                    return 0;
-                }
-            }
-        }
-
-        public int BitDepth {
-            get {
-                if (_camera != null) {
-                    return _camera.BitsPerPixel;
-                } else {
-                    return 0;
-                }
-            }
-        }
-
-        public bool CanGetGain => GetAvailableIsoOptions().Any();
-
-        public bool CanSetGain => CanGetGain;
-
-        public int GainMax {
-            get {
-                var isoOptions = GetAvailableIsoOptions();
-                if (!isoOptions.Any()) {
-                    if (_camera != null) {
-                        Logger.Error("Problem getting gain max: camera did not report ISO options.");
-                    }
-                    return -1;
-                }
-
-                return (int)isoOptions.Last().Value;
-            }
-        }
-
-        public int GainMin {
-            get {
-                var isoOptions = GetAvailableIsoOptions();
-                if (!isoOptions.Any()) {
-                    if (_camera != null) {
-                        Logger.Error("Problem getting gain min: camera did not report ISO options.");
-                    }
-                    return -1;
-                }
-
-                return (int)isoOptions.Min(o => o.Value);
-            }
-        }
-
-        public int Gain {
-            get {
-                if (_camera != null) {
-                    try {
-                        PropertyValue value = GetPropertyValue(PROPID_ISO);
-
-                        return (int)(value.Value == 0xffffff ? 0 : value.Value);
-                    } catch (Exception ex) {
-                        Logger.Error("Problem getting gain", ex);
-                        return -1;
-                    }
-                } else {
+                catch (Exception ex)
+                {
+                    Logger.Error("Problem getting gain", ex);
                     return -1;
                 }
             }
+            else
+            {
+                return -1;
+            }
+        }
 
-            set {
-                if (_camera != null) {
-                    try {
-                        SonyDriver.GetInstance().SetProperty(_camera.Handle, PROPID_ISO, (uint)value);
-                        RaisePropertyChanged(nameof(Gain));
-                    } catch (Exception ex) {
-                        Logger.Error($"Problem setting gain to {value}", ex);
-                    }
+        set
+        {
+            if (_camera != null)
+            {
+                try
+                {
+                    SonyDriver.GetInstance().SetProperty(_camera.Handle, PROPID_ISO, (uint)value);
+                    RaisePropertyChanged(nameof(Gain));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Problem setting gain to {value}", ex);
                 }
             }
         }
+    }
 
-        public IList<int> Gains {
-            get {
-                List<int> gains = new List<int>();
-
-                foreach (var iso in GetAvailableIsoOptions()) {
-                    if (iso.Value == 0xffffff) {
-                        gains.Add(0); // AUTO
-                    } else {
-                        gains.Add((int)iso.Value);
-                    }
+    public int GainMax
+    {
+        get
+        {
+            var isoOptions = GetAvailableIsoOptions();
+            if (!isoOptions.Any())
+            {
+                if (_camera != null)
+                {
+                    Logger.Error("Problem getting gain max: camera did not report ISO options.");
                 }
-
-                return gains;
+                return -1;
             }
+
+            return (int)isoOptions.Last().Value;
         }
+    }
 
-        public string Id => "Sony";
-
-        public string Name {
-            get => _device.Model;
-            set => throw new NotImplementedException();
-        }
-
-        public string DisplayName {
-            get => _device.Model;
-            set => throw new NotImplementedException();
-        }
-
-        public string Category { get => "Sony"; }
-
-        public bool Connected {
-            get {
-                return _camera != null;
+    public int GainMin
+    {
+        get
+        {
+            var isoOptions = GetAvailableIsoOptions();
+            if (!isoOptions.Any())
+            {
+                if (_camera != null)
+                {
+                    Logger.Error("Problem getting gain min: camera did not report ISO options.");
+                }
+                return -1;
             }
-        }
 
-        public string Description {
-            get {
-                if (_camera != null) {
-                    return _camera.GetDescription();
-                } else {
-                    return _device.GetDescription();
+            return (int)isoOptions.Min(o => o.Value);
+        }
+    }
+
+    public IList<int> Gains
+    {
+        get
+        {
+            List<int> gains = new List<int>();
+
+            foreach (var iso in GetAvailableIsoOptions())
+            {
+                if (iso.Value == 0xffffff)
+                {
+                    gains.Add(0); // AUTO
+                }
+                else
+                {
+                    gains.Add((int)iso.Value);
                 }
             }
+
+            return gains;
         }
+    }
 
-        public string DriverInfo => "https://retro.kiwi";
+    public bool HasBattery => true;
+    public bool HasDewHeater => false;
 
-        public string DriverVersion => string.Empty;
+    // TODO!!! WE NEED ONE
+    public bool HasSetupDialog => false;
 
-        public double TemperatureSetPoint {
-            get => double.NaN;
+    public bool HasShutter => true;
+    public string Id => "Sony";
 
-            set {
+    public bool LiveViewEnabled
+    {
+        get => _liveViewEnabled;
+        set
+        {
+            _liveViewEnabled = value;
+            RaisePropertyChanged();
+        }
+    }
+
+    public short MaxBinX { get => 1; set => throw new NotImplementedException(); }
+    public short MaxBinY { get => 1; set => throw new NotImplementedException(); }
+
+    public string Name
+    {
+        get => _device.Model;
+        set => throw new NotImplementedException();
+    }
+
+    public int Offset { get => -1; set => throw new NotImplementedException(); }
+    public int OffsetMax => 0;
+    public int OffsetMin => 0;
+
+    public double PixelSizeX
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return _camera.PixelWidth;
+            }
+            else
+            {
+                return double.NaN;
             }
         }
+    }
 
-        public bool CanSubSample => false;
-
-        public bool EnableSubSample { get; set; }
-
-        public int SubSampleX { get; set; }
-
-        public int SubSampleY { get; set; }
-
-        public int SubSampleWidth { get; set; }
-
-        public int SubSampleHeight { get; set; }
-
-        public bool CoolerOn {
-            get => false;
-            set {
+    public double PixelSizeY
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return _camera.PixelHeight;
+            }
+            else
+            {
+                return double.NaN;
             }
         }
+    }
 
-        public double CoolerPower => double.NaN;
+    public short ReadoutMode
+    {
+        get => 0;
+        set { }
+    }
 
-        public bool HasDewHeater => false;
+    public short ReadoutModeForNormalImages
+    {
+        get => _readoutModeForNormalImages;
+        set
+        {
+            _readoutModeForNormalImages = value;
+            RaisePropertyChanged();
+        }
+    }
 
-        public bool DewHeaterOn {
-            get => false;
-            set {
+    public short ReadoutModeForSnapImages
+    {
+        get => _readoutModeForSnapImages;
+        set
+        {
+            _readoutModeForSnapImages = value;
+            RaisePropertyChanged();
+        }
+    }
+
+    public IList<string> ReadoutModes => new List<string> { "Default" };
+
+    public string SensorName
+    {
+        get
+        {
+            if (_camera != null)
+            {
+                return _camera.SensorName;
+            }
+            else
+            {
+                return string.Empty;
             }
         }
+    }
 
-        public bool CanSetOffset => false;
+    public SensorType SensorType { get => SensorType.RGGB; set => throw new NotImplementedException(); }
+    public int SubSampleHeight { get; set; }
+    public int SubSampleWidth { get; set; }
+    public int SubSampleX { get; set; }
+    public int SubSampleY { get; set; }
+    public IList<string> SupportedActions => new List<string>();
 
-        public int Offset { get => -1; set => throw new NotImplementedException(); }
+    // Although the driver supports camera temperature, it gets it from the ARW's
+    // metadata after a photo is taken, because this code doesn't request processed
+    // ARW, the temp cannot be determined.
+    public double Temperature
+    {
+        get => double.NaN;
+        /*{
 
-        public int OffsetMin => 0;
-
-        public int OffsetMax => 0;
-
-        public bool CanSetUSBLimit => false;
-
-        public int USBLimit { get => -1; set => throw new NotImplementedException(); }
-
-        public int USBLimitMin => -1;
-
-        public int USBLimitMax => -1;
-
-        public int USBLimitStep => -1;
-
-        public double ElectronsPerADU => double.NaN;
-
-        public IList<string> ReadoutModes => new List<string> { "Default" };
-
-        public short ReadoutMode {
-            get => 0;
-            set { }
-        }
-
-        public short ReadoutModeForSnapImages {
-            get => _readoutModeForSnapImages;
-            set {
-                _readoutModeForSnapImages = value;
-                RaisePropertyChanged();
-            }
-        }
-
-        public short ReadoutModeForNormalImages {
-            get => _readoutModeForNormalImages;
-            set {
-                _readoutModeForNormalImages = value;
-                RaisePropertyChanged();
-            }
-        }
-
-        public AsyncObservableCollection<BinningMode> BinningModes {
-            get {
-                if (_binningModes == null) {
-                    _binningModes = new AsyncObservableCollection<BinningMode>();
-                    _binningModes.Add(new BinningMode(1, 1));
-                }
-
-                return _binningModes;
-            }
-        }
-
-        #endregion
-
-        #region Supported Methods
-
-        public void StartLiveView(CaptureSequence sequence) {
-            LiveViewEnabled = true;
-        }
-
-        public void StopLiveView() {
-            LiveViewEnabled = false;
-        }
-
-        public Task<bool> Connect(CancellationToken token) {
-            return Task.Run<bool>(() => {
-                try {
-                    _camera = SonyDriver.GetInstance().OpenCamera(_device.Id);
-                } catch (Exception ex) {
-                    Logger.Error(ex);
-                    _camera = null;
-                }
-
-                NotifyGainPropertiesChanged();
-                return _camera != null;
-            });
-        }
-
-        public void Disconnect() {
             if (_camera != null) {
-                try {
-                    SonyDriver.GetInstance().CloseCamera(_camera.Handle);
-                } catch (Exception ex) {
-                    Logger.Error(ex);
-                }
+                PropertyValue value = GetPropertyValue(PROPID_TEMPERATURE);
 
-                _camera = null;
-                NotifyGainPropertiesChanged();
-            }
-        }
-
-        public Task<IExposureData> DownloadLiveView(CancellationToken token) {
-            return Task.Run<IExposureData>(() => {
-                using (var memStream = new MemoryStream(SonyDriver.GetInstance().GetLiveView(_camera.Handle))) {
-                    memStream.Position = 0;
-
-                    JpegBitmapDecoder decoder =
-                        new JpegBitmapDecoder(memStream, BitmapCreateOptions.IgnoreColorProfile, BitmapCacheOption.OnLoad);
-
-                    FormatConvertedBitmap bitmap = new FormatConvertedBitmap();
-                    bitmap.BeginInit();
-                    bitmap.Source = decoder.Frames[0];
-                    bitmap.DestinationFormat = System.Windows.Media.PixelFormats.Gray16;
-                    bitmap.EndInit();
-
-                    ushort[] outArray = new ushort[bitmap.PixelWidth * bitmap.PixelHeight];
-                    bitmap.CopyPixels(outArray, 2 * bitmap.PixelWidth, 0);
-
-                    var metaData = new ImageMetaData();
-
-                    return _exposureDataFactory.CreateImageArrayExposureData(
-                        input: outArray,
-                        width: bitmap.PixelWidth,
-                        height: bitmap.PixelHeight,
-                        bitDepth: 16,
-                        isBayered: false,
-                        metaData: metaData);
-                }
-            });
-        }
-
-        public void SetupDialog() {
-            throw new NotImplementedException();
-        }
-
-        public void StartExposure(CaptureSequence sequence) {
-            if (_camera != null) {
-                SonyDriver driver = SonyDriver.GetInstance();
-                lock (_captureLock) {
-                    _softCancelRequested = false;
-                    if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
-                        Logger.Warning("Cannot start exposure: capture status unavailable.");
-                        throw new TaskCanceledException("Cannot start exposure: capture status unavailable.");
-                    } else {
-                        if (BUSY_STATES.Contains(captureStatus)) {
-                            if (_enableNativeCancel) {
-                                TryCancelCapture("start exposure reset");
-                            }
-                            Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
-                            throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
-                        }
-
-                        if (!IDLE_STATES.Contains(captureStatus)) {
-                            Logger.Warning($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
-                            throw new TaskCanceledException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
-                        }
-                    }
-                }
-
-                lock (_captureLock) {
-                    double exposureTime = sequence.ExposureTime;
-                    driver.StartCapture(_camera.Handle, (float)exposureTime);
-                }
-            }
-        }
-
-        public void StopExposure() {
-            AbortExposure();
-        }
-
-        public void AbortExposure() {
-            if (_enableNativeCancel) {
-                TryCancelCapture("abort request");
+                return (value.Value) / 10.0;
             } else {
-                _softCancelRequested = true;
-                Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
+                return double.NaN;
             }
+        }*/
+    }
+
+    public double TemperatureSetPoint
+    {
+        get => double.NaN;
+
+        set
+        {
         }
+    }
 
-        public async Task WaitUntilExposureIsReady(CancellationToken token) {
-            using (token.Register(AbortExposure)) {
-                uint[] completionStates = { CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
+    public int USBLimit { get => -1; set => throw new NotImplementedException(); }
+    public int USBLimitMax => -1;
+    public int USBLimitMin => -1;
+    public int USBLimitStep => -1;
+    #endregion
 
-                SonyDriver driver = SonyDriver.GetInstance();
+    #region fields
+    private AsyncObservableCollection<BinningMode> _binningModes;
+    private SonyCameraInfo _camera = null;
+    private readonly object _captureLock = new object();
+    private SonyDevice _device = null;
+    private readonly bool _enableNativeCancel;
+    private readonly IExposureDataFactory _exposureDataFactory;
+    private bool _liveViewEnabled;
+    private IProfileService _profileService;
+    private short _readoutModeForNormalImages;
+    private short _readoutModeForSnapImages;
+    private bool _softCancelRequested;
+    private static readonly uint[] BUSY_STATES = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
+    private static readonly uint[] CANCELLABLE_STATES = BUSY_STATES;
+    private static readonly uint[] IDLE_STATES = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
+    #endregion
 
-                try {
-                    uint captureStatus;
-                    lock (_captureLock) {
-                        if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait begin")) {
-                            throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
-                        }
-                    }
-                    Logger.Info(
-                        $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", completionStates)}");
+    public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, bool enableNativeCancel)
+    {
+        _profileService = profileService;
+        _exposureDataFactory = exposureDataFactory;
+        _device = device;
+        _enableNativeCancel = enableNativeCancel;
+        _softCancelRequested = false;
+    }
 
-                    while (!completionStates.Contains(captureStatus)) {
-                        await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), token);
-                        if (!_enableNativeCancel && token.IsCancellationRequested) {
-                            _softCancelRequested = true;
-                        }
+    #region methods
 
-                        lock (_captureLock) {
-                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll")) {
-                                throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
-                            }
-                        }
-                    }
+    public void AbortExposure()
+    {
+        if (_enableNativeCancel)
+        {
+            TryCancelCapture("abort request");
+        }
+        else
+        {
+            _softCancelRequested = true;
+            Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
+        }
+    }
 
-                    Logger.Info($"Wait for image ready complete, completion state is {captureStatus}");
-                    if (_softCancelRequested || token.IsCancellationRequested) {
-                        _softCancelRequested = false;
-                        throw new TaskCanceledException("Exposure cancelled by user (soft cancel).");
-                    }
-                } catch (TaskCanceledException) {
-                    Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
-                    throw;
-                } catch (Exception ex) {
-                    Logger.Error("WaitUntilExposureIsReady got exception", ex);
-                    throw new SonyException("Problem while waiting for image to be ready (see log)");
-                }
+    public string Action(string actionName, string actionParameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<bool> Connect(CancellationToken token)
+    {
+        return Task.Run<bool>(() =>
+        {
+            try
+            {
+                _camera = SonyDriver.GetInstance().OpenCamera(_device.Id);
             }
-        }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+                _camera = null;
+            }
 
-        public Task<IExposureData> DownloadExposure(CancellationToken token) {
-            return Task.Run<IExposureData>(() => {
-                byte[] rawImageData = SonyDriver.GetInstance().GetLastImage();
+            NotifyGainPropertiesChanged();
+            return _camera != null;
+        });
+    }
+
+    public void Disconnect()
+    {
+        if (_camera != null)
+        {
+            try
+            {
+                SonyDriver.GetInstance().CloseCamera(_camera.Handle);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+
+            _camera = null;
+            NotifyGainPropertiesChanged();
+        }
+    }
+
+    public Task<IExposureData> DownloadExposure(CancellationToken token)
+    {
+        return Task.Run<IExposureData>(() =>
+        {
+            byte[] rawImageData = SonyDriver.GetInstance().GetLastImage();
+
+            var metaData = new ImageMetaData();
+
+            return _exposureDataFactory.CreateRAWExposureData(
+                converter: _profileService.ActiveProfile.CameraSettings.RawConverter,
+                rawBytes: rawImageData,
+                rawType: "arw",
+                bitDepth: this.BitDepth,
+                metaData: metaData);
+        });
+    }
+
+    public Task<IExposureData> DownloadLiveView(CancellationToken token)
+    {
+        return Task.Run<IExposureData>(() =>
+        {
+            using (var memStream = new MemoryStream(SonyDriver.GetInstance().GetLiveView(_camera.Handle)))
+            {
+                memStream.Position = 0;
+
+                JpegBitmapDecoder decoder =
+                    new JpegBitmapDecoder(memStream, BitmapCreateOptions.IgnoreColorProfile, BitmapCacheOption.OnLoad);
+
+                FormatConvertedBitmap bitmap = new FormatConvertedBitmap();
+                bitmap.BeginInit();
+                bitmap.Source = decoder.Frames[0];
+                bitmap.DestinationFormat = System.Windows.Media.PixelFormats.Gray16;
+                bitmap.EndInit();
+
+                ushort[] outArray = new ushort[bitmap.PixelWidth * bitmap.PixelHeight];
+                bitmap.CopyPixels(outArray, 2 * bitmap.PixelWidth, 0);
 
                 var metaData = new ImageMetaData();
 
-                return _exposureDataFactory.CreateRAWExposureData(
-                    converter: _profileService.ActiveProfile.CameraSettings.RawConverter,
-                    rawBytes: rawImageData,
-                    rawType: "arw",
-                    bitDepth: this.BitDepth,
+                return _exposureDataFactory.CreateImageArrayExposureData(
+                    input: outArray,
+                    width: bitmap.PixelWidth,
+                    height: bitmap.PixelHeight,
+                    bitDepth: 16,
+                    isBayered: false,
                     metaData: metaData);
-            });
-        }
-        #endregion
-
-        #region Unsupported Methods
-
-        public string Action(string actionName, string actionParameters) {
-            throw new NotImplementedException();
-        }
-
-
-        public void SendCommandBlind(string command, bool raw = true) {
-            throw new NotImplementedException();
-        }
-
-        public bool SendCommandBool(string command, bool raw = true) {
-            throw new NotImplementedException();
-        }
-
-        public string SendCommandString(string command, bool raw = true) {
-            throw new NotImplementedException();
-        }
-
-        public void SetBinning(short x, short y) {
-            // Ignore
-        }
-        
-        public void UpdateSubSampleArea() {
-            if (_camera == null) {
-                EnableSubSample = false;
-                SubSampleX = 0;
-                SubSampleY = 0;
-                SubSampleWidth = 0;
-                SubSampleHeight = 0;
-                return;
             }
+        });
+    }
 
-            if (EnableSubSample && !CanSubSample) {
-                Logger.Warning("Sub-sampling requested but not supported for Sony cameras. Falling back to full frame.");
-                EnableSubSample = false;
+    public void SendCommandBlind(string command, bool raw = true)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool SendCommandBool(string command, bool raw = true)
+    {
+        throw new NotImplementedException();
+    }
+
+    public string SendCommandString(string command, bool raw = true)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void SetBinning(short x, short y)
+    {
+        // Ignore
+    }
+
+    public void SetupDialog()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void StartExposure(CaptureSequence sequence)
+    {
+        if (_camera != null)
+        {
+            SonyDriver driver = SonyDriver.GetInstance();
+            lock (_captureLock)
+            {
+                _softCancelRequested = false;
+                if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight"))
+                {
+                    Logger.Warning("Cannot start exposure: capture status unavailable.");
+                    throw new TaskCanceledException("Cannot start exposure: capture status unavailable.");
+                }
+
+
+
+
+
+                if (BUSY_STATES.Contains(captureStatus))
+                {
+                    if (_enableNativeCancel)
+                    {
+                        TryCancelCapture("start exposure reset");
+                    }
+                    Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
+                    throw new TaskCanceledException("Cannot start exposure: Camera is still busy with a previous exposure.");
+                }
+
+                if (!IDLE_STATES.Contains(captureStatus))
+                {
+                    Logger.Warning($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
+                    throw new TaskCanceledException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
+                }
+
+                double exposureTime = sequence.ExposureTime;
+                driver.StartCapture(_camera.Handle, (float)exposureTime);
             }
+        }
+    }
 
-            // Sony cameras currently expose the entire frame, so always reset to the sensor dimensions.
+    public void StartLiveView(CaptureSequence sequence)
+    {
+        LiveViewEnabled = true;
+    }
+
+    public void StopExposure()
+    {
+        AbortExposure();
+    }
+
+    public void StopLiveView()
+    {
+        LiveViewEnabled = false;
+    }
+
+    public void UpdateSubSampleArea()
+    {
+        if (_camera == null)
+        {
+            EnableSubSample = false;
             SubSampleX = 0;
             SubSampleY = 0;
-            SubSampleWidth = _camera.ImageSize.Width;
-            SubSampleHeight = _camera.ImageSize.Height;
+            SubSampleWidth = 0;
+            SubSampleHeight = 0;
+            return;
         }
 
-        #endregion
+        if (EnableSubSample && !CanSubSample)
+        {
+            Logger.Warning("Sub-sampling requested but not supported for Sony cameras. Falling back to full frame.");
+            EnableSubSample = false;
+        }
 
-
-        // TODO!!! WE NEED ONE
-        public bool HasSetupDialog => false;
-
-        public IList<string> SupportedActions => new List<string>();
+        // Sony cameras currently expose the entire frame, so always reset to the sensor dimensions.
+        SubSampleX = 0;
+        SubSampleY = 0;
+        SubSampleWidth = _camera.ImageSize.Width;
+        SubSampleHeight = _camera.ImageSize.Height;
     }
+
+    public async Task WaitUntilExposureIsReady(CancellationToken token)
+    {
+        using (token.Register(AbortExposure))
+        {
+            uint[] completionStates = { CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
+
+            SonyDriver driver = SonyDriver.GetInstance();
+
+            try
+            {
+                uint captureStatus;
+                lock (_captureLock)
+                {
+                    if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait begin"))
+                    {
+                        throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
+                    }
+                }
+                Logger.Info(
+                    $"Waiting for image to be ready, current state is {captureStatus}, completion states are {String.Join(", ", completionStates)}");
+
+                while (!completionStates.Contains(captureStatus))
+                {
+                    await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), token);
+                    if (!_enableNativeCancel && token.IsCancellationRequested)
+                    {
+                        _softCancelRequested = true;
+                    }
+
+                    lock (_captureLock)
+                    {
+                        if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll"))
+                        {
+                            throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
+                        }
+                    }
+                }
+
+                Logger.Info($"Wait for image ready complete, completion state is {captureStatus}");
+                if (_softCancelRequested || token.IsCancellationRequested)
+                {
+                    _softCancelRequested = false;
+                    throw new TaskCanceledException("Exposure cancelled by user (soft cancel).");
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("WaitUntilExposureIsReady got exception", ex);
+                throw new SonyException("Problem while waiting for image to be ready (see log)");
+            }
+        }
+    }
+
+    private IReadOnlyList<PropertyValueOption> GetAvailableIsoOptions()
+    {
+        if (_camera == null)
+        {
+            return Array.Empty<PropertyValueOption>();
+        }
+
+        uint[] propertyCandidates = { PROPID_ISOS, PROPID_ISO };
+
+        foreach (var propertyId in propertyCandidates)
+        {
+            try
+            {
+                var options = _camera.GetPropertyInfo(propertyId)?.Options()?.Where(o => o.Value <= 0x00FFFFFF).ToList();
+                if (options != null && options.Count > 0)
+                {
+                    return options;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Unable to enumerate ISO options for property 0x{propertyId:X}: {ex.Message}");
+            }
+        }
+
+        Logger.Warning("Camera did not report any ISO options via known properties (registry ISO list may be empty until the camera learns it).");
+        return Array.Empty<PropertyValueOption>();
+    }
+
+    private PropertyValue GetPropertyValue(uint id)
+    {
+        return SonyDriver.GetInstance().GetProperty(_camera.Handle, id);
+    }
+
+    private void NotifyGainPropertiesChanged()
+    {
+        RaisePropertyChanged(nameof(CanGetGain));
+        RaisePropertyChanged(nameof(CanSetGain));
+        RaisePropertyChanged(nameof(GainMin));
+        RaisePropertyChanged(nameof(GainMax));
+        RaisePropertyChanged(nameof(Gain));
+        RaisePropertyChanged(nameof(Gains));
+    }
+
+    private bool TryCancelCapture(string reason)
+    {
+        if (_camera == null)
+        {
+            return false;
+        }
+
+        if (!_enableNativeCancel)
+        {
+            Logger.Info($"Native cancel disabled; skipping cancel ({reason})");
+            return false;
+        }
+
+        lock (_captureLock)
+        {
+            try
+            {
+                SonyDriver driver = SonyDriver.GetInstance();
+                if (!TryGetCaptureStatusLocked(driver, out var status, reason))
+                {
+                    return false;
+                }
+
+                if (!CANCELLABLE_STATES.Contains(status))
+                {
+                    Logger.Debug($"Skip cancel ({reason}); capture status is {status}");
+                    return false;
+                }
+
+                Logger.Info($"Issuing cancel ({reason}); capture status is {status}");
+                driver.CancelCapture(_camera.Handle);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"CancelCapture failed ({reason})", ex);
+                return false;
+            }
+        }
+    }
+
+    private bool TryGetCaptureStatusLocked(SonyDriver driver, out uint status, string reason)
+    {
+        try
+        {
+            status = driver.GetCaptureStatus(_camera.Handle);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning($"Unable to get capture status ({reason}): {ex.Message}");
+            status = CAPTURE_FAILED;
+            return false;
+        }
+    }
+
+    #endregion 
 }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -39,6 +39,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private const uint CAPTURE_READING    = 0x8002;
         private const uint CAPTURE_PROCESSING = 0x8003;
         private readonly bool _enableNativeCancel;
+        private bool _softCancelRequested;
 
         private SonyCameraInfo _camera = null;
         private SonyDevice _device = null;
@@ -55,6 +56,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             _exposureDataFactory = exposureDataFactory;
             _device = device;
             _enableNativeCancel = enableNativeCancel;
+            _softCancelRequested = false;
         }
 
         #region Internal Helpers
@@ -566,6 +568,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                 SonyDriver driver = SonyDriver.GetInstance();
                 bool shouldCancel = false;
                 lock (_captureLock) {
+                    _softCancelRequested = false;
                     if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
                         Logger.Warning("Starting exposure without capture status due to read failure.");
                     } else if (captureStatus == CAPTURE_CAPTURING || captureStatus == CAPTURE_PROCESSING || captureStatus == CAPTURE_STARTING ||
@@ -594,6 +597,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             if (_enableNativeCancel) {
                 TryCancelCapture("abort request");
             } else {
+                _softCancelRequested = true;
                 Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
             }
         }
@@ -616,9 +620,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
                     while (!completionStates.Contains(captureStatus)) {
                         await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), token);
-                        if (token.IsCancellationRequested) {
-                            Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
-                            return;
+                        if (!_enableNativeCancel && token.IsCancellationRequested) {
+                            _softCancelRequested = true;
                         }
 
                         lock (_captureLock) {
@@ -629,8 +632,13 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                     }
 
                     Logger.Info($"Wait for image ready complete, completion state is {captureStatus}");
+                    if (_softCancelRequested || token.IsCancellationRequested) {
+                        _softCancelRequested = false;
+                        throw new TaskCanceledException("Exposure cancelled by user (soft cancel).");
+                    }
                 } catch (TaskCanceledException) {
                     Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
+                    throw;
                 } catch (Exception ex) {
                     Logger.Error("WaitUntilExposureIsReady got exception", ex);
                     throw new SonyException("Problem while waiting for image to be ready (see log)");

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -566,7 +566,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         public void StartExposure(CaptureSequence sequence) {
             if (_camera != null) {
                 SonyDriver driver = SonyDriver.GetInstance();
-                bool shouldCancel = false;
+                bool canStart = false;
+                bool requestCancel = false;
                 lock (_captureLock) {
                     _softCancelRequested = false;
                     if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
@@ -577,21 +578,22 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
                         if (busyStates.Contains(captureStatus)) {
                             Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
-                            if (_enableNativeCancel) {
-                                shouldCancel = true;
-                            } else {
-                                // Do not attempt to start while camera is busy when native cancel is disabled
-                                return;
-                            }
+                            requestCancel = _enableNativeCancel;
                         } else if (!idleStates.Contains(captureStatus)) {
                             Logger.Warning($"Unexpected capture status {captureStatus} before start; skipping start.");
-                            return;
+                        } else {
+                            canStart = true;
                         }
                     }
                 }
 
-                if (shouldCancel) {
+                if (requestCancel) {
                     TryCancelCapture("start exposure reset");
+                    return;
+                }
+
+                if (!canStart) {
+                    return;
                 }
 
                 lock (_captureLock) {

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -38,6 +38,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private const uint CAPTURE_STARTING   = 0x8001;
         private const uint CAPTURE_READING    = 0x8002;
         private const uint CAPTURE_PROCESSING = 0x8003;
+        private const bool ENABLE_NATIVE_CANCEL = false; // native CancelCapture is unstable on some bodies
 
         private SonyCameraInfo _camera = null;
         private SonyDevice _device = null;
@@ -94,6 +95,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         private bool TryCancelCapture(string reason) {
             if (_camera == null) {
+                return false;
+            }
+
+            if (!ENABLE_NATIVE_CANCEL) {
+                Logger.Info($"Native cancel disabled; skipping cancel ({reason})");
                 return false;
             }
 
@@ -584,7 +590,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         }
 
         public void AbortExposure() {
-            TryCancelCapture("abort request");
+            Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
         }
 
         public async Task WaitUntilExposureIsReady(CancellationToken token) {
@@ -605,6 +611,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
                     while (!completionStates.Contains(captureStatus)) {
                         await CoreUtil.Wait(TimeSpan.FromMilliseconds(100), token);
+                        if (token.IsCancellationRequested) {
+                            Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
+                            return;
+                        }
+
                         lock (_captureLock) {
                             if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll")) {
                                 throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
@@ -613,6 +624,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                     }
 
                     Logger.Info($"Wait for image ready complete, completion state is {captureStatus}");
+                } catch (TaskCanceledException) {
+                    Logger.Info("WaitUntilExposureIsReady cancelled by token; exiting without native cancel.");
                 } catch (Exception ex) {
                     Logger.Error("WaitUntilExposureIsReady got exception", ex);
                     throw new SonyException("Problem while waiting for image to be ready (see log)");

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -38,6 +38,8 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private const uint CAPTURE_STARTING   = 0x8001;
         private const uint CAPTURE_READING    = 0x8002;
         private const uint CAPTURE_PROCESSING = 0x8003;
+        private static readonly uint[] IDLE_STATES = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
+        private static readonly uint[] BUSY_STATES = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
         private readonly bool _enableNativeCancel;
         private bool _softCancelRequested;
 
@@ -113,8 +115,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                         return false;
                     }
 
-                    uint[] cancellableStates = { CAPTURE_CAPTURING, CAPTURE_STARTING, CAPTURE_READING, CAPTURE_PROCESSING };
-                    if (!cancellableStates.Contains(status)) {
+                    if (!BUSY_STATES.Contains(status)) {
                         Logger.Debug($"Skip cancel ({reason}); capture status is {status}");
                         return false;
                     }
@@ -566,39 +567,27 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         public void StartExposure(CaptureSequence sequence) {
             if (_camera != null) {
                 SonyDriver driver = SonyDriver.GetInstance();
-                bool canStart = false;
-                bool requestCancel = false;
                 lock (_captureLock) {
                     _softCancelRequested = false;
                     if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
-                        Logger.Warning("Starting exposure without capture status due to read failure.");
+                        throw new SonyException("Cannot start exposure: capture status unavailable.");
                     } else {
-                        uint[] idleStates = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
-                        uint[] busyStates = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
+                        if (BUSY_STATES.Contains(captureStatus)) {
+                            if (_enableNativeCancel) {
+                                TryCancelCapture("start exposure reset");
+                            }
+                            throw new SonyException("Cannot start exposure: Camera is still busy with a previous exposure.");
+                        }
 
-                        if (busyStates.Contains(captureStatus)) {
-                            Notification.ShowWarning("Camera is still busy with a previous exposure. Skipping new start.");
-                            requestCancel = _enableNativeCancel;
-                        } else if (!idleStates.Contains(captureStatus)) {
-                            Logger.Warning($"Unexpected capture status {captureStatus} before start; skipping start.");
-                        } else {
-                            canStart = true;
+                        if (!IDLE_STATES.Contains(captureStatus)) {
+                            throw new SonyException($"Cannot start exposure: Camera in unexpected capture status ({captureStatus}).");
                         }
                     }
                 }
 
-                if (requestCancel) {
-                    TryCancelCapture("start exposure reset");
-                    return;
-                }
-
-                if (!canStart) {
-                    return;
-                }
-
                 lock (_captureLock) {
                     double exposureTime = sequence.ExposureTime;
-                    driver.StartCapture(_camera.Handle, (float)exposureTime); //);
+                    driver.StartCapture(_camera.Handle, (float)exposureTime);
                 }
             }
         }

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -38,7 +38,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private const uint CAPTURE_STARTING   = 0x8001;
         private const uint CAPTURE_READING    = 0x8002;
         private const uint CAPTURE_PROCESSING = 0x8003;
-        private const bool ENABLE_NATIVE_CANCEL = false; // native CancelCapture is unstable on some bodies
+        private readonly bool _enableNativeCancel;
 
         private SonyCameraInfo _camera = null;
         private SonyDevice _device = null;
@@ -50,10 +50,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private AsyncObservableCollection<BinningMode> _binningModes;
         private readonly object _captureLock = new object();
 
-        public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device) {
+        public CameraDriver(IProfileService profileService, IExposureDataFactory exposureDataFactory, SonyDevice device, bool enableNativeCancel) {
             _profileService = profileService;
             _exposureDataFactory = exposureDataFactory;
             _device = device;
+            _enableNativeCancel = enableNativeCancel;
         }
 
         #region Internal Helpers
@@ -98,7 +99,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                 return false;
             }
 
-            if (!ENABLE_NATIVE_CANCEL) {
+            if (!_enableNativeCancel) {
                 Logger.Info($"Native cancel disabled; skipping cancel ({reason})");
                 return false;
             }
@@ -590,7 +591,11 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         }
 
         public void AbortExposure() {
-            Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
+            if (_enableNativeCancel) {
+                TryCancelCapture("abort request");
+            } else {
+                Logger.Info("AbortExposure requested; native cancel disabled; letting capture finish.");
+            }
         }
 
         public async Task WaitUntilExposureIsReady(CancellationToken token) {

--- a/Drivers/CameraDriver.cs
+++ b/Drivers/CameraDriver.cs
@@ -38,6 +38,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private const uint CAPTURE_STARTING   = 0x8001;
         private const uint CAPTURE_READING    = 0x8002;
         private const uint CAPTURE_PROCESSING = 0x8003;
+        private const uint CAPTURE_STATUS_UNKNOWN = 0xFFFFFFFF;
         private static readonly uint[] IDLE_STATES = { CAPTURE_CREATED, CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
         private static readonly uint[] BUSY_STATES = { CAPTURE_CAPTURING, CAPTURE_PROCESSING, CAPTURE_STARTING, CAPTURE_READING };
         private static readonly uint[] COMPLETION_STATES = { CAPTURE_CANCELLED, CAPTURE_COMPLETE, CAPTURE_FAILED };
@@ -113,7 +114,12 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             lock (_captureLock) {
                 try {
                     SonyDriver driver = SonyDriver.GetInstance();
-                    if (!TryGetCaptureStatusLocked(driver, out var status, reason)) {
+                    if (!TryGetCaptureStatus(driver, out var status, reason)) {
+                        return false;
+                    }
+
+                    if (status == CAPTURE_STATUS_UNKNOWN) {
+                        Logger.Warning($"Skip cancel ({reason}); capture status is unknown (camera did not respond).");
                         return false;
                     }
 
@@ -132,13 +138,13 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             }
         }
 
-        private bool TryGetCaptureStatusLocked(SonyDriver driver, out uint status, string reason) {
+        private bool TryGetCaptureStatus(SonyDriver driver, out uint status, string reason) {
             try {
                 status = driver.GetCaptureStatus(_camera.Handle);
                 return true;
             } catch (Exception ex) {
-                Logger.Warning($"Unable to get capture status ({reason}): {ex.Message}");
-                status = CAPTURE_FAILED;
+                Logger.Warning($"Unable to get capture status ({reason}); camera may not have responded: {ex.Message}");
+                status = CAPTURE_STATUS_UNKNOWN;
                 return false;
             }
         }
@@ -571,14 +577,15 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                 SonyDriver driver = SonyDriver.GetInstance();
                 lock (_captureLock) {
                     _softCancelRequested = false;
-                    if (!TryGetCaptureStatusLocked(driver, out var captureStatus, "start exposure preflight")) {
+                    if (!TryGetCaptureStatus(driver, out var captureStatus, "start exposure preflight") ||
+                        captureStatus == CAPTURE_STATUS_UNKNOWN) {
                         Logger.Warning("Cannot start exposure: capture status unavailable.");
                         throw new TaskCanceledException("Cannot start exposure: capture status unavailable.");
                     }
 
                     if (BUSY_STATES.Contains(captureStatus)) {
                         TryCancelCaptureIfEnabled("start exposure reset");
-                        if (_enableNativeCancel && !TryGetCaptureStatusLocked(driver, out captureStatus, "start exposure post-cancel")) {
+                        if (_enableNativeCancel && (!TryGetCaptureStatus(driver, out captureStatus, "start exposure post-cancel") || captureStatus == CAPTURE_STATUS_UNKNOWN)) {
                             Logger.Warning("Cannot start exposure: capture status unavailable after cancel.");
                             throw new TaskCanceledException("Cannot start exposure: capture status unavailable after cancel.");
                         }
@@ -624,7 +631,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                 try {
                     uint captureStatus;
                     lock (_captureLock) {
-                        if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait begin")) {
+                        if (!TryGetCaptureStatus(driver, out captureStatus, "wait begin") || captureStatus == CAPTURE_STATUS_UNKNOWN) {
                             throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
                         }
                     }
@@ -639,7 +646,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
                         }
 
                         lock (_captureLock) {
-                            if (!TryGetCaptureStatusLocked(driver, out captureStatus, "wait poll")) {
+                            if (!TryGetCaptureStatus(driver, out captureStatus, "wait poll") || captureStatus == CAPTURE_STATUS_UNKNOWN) {
                                 throw new SonyException("Problem while waiting for image to be ready (status unavailable)");
                             }
                         }

--- a/Drivers/CameraProvider.cs
+++ b/Drivers/CameraProvider.cs
@@ -10,8 +10,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.ComponentModel.Composition;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using NINA.RetroKiwi.Plugin.SonyCamera;
 using NINA.Image.Interfaces;
 using NINA.WPF.Base.Mediator;
@@ -29,14 +27,12 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private IExposureDataFactory exposureDataFactory;
         SonyDriver driver;
         private readonly PluginOptionsAccessor pluginSettings;
-        private static readonly Guid PluginGuid =
-            Guid.Parse(((GuidAttribute)Attribute.GetCustomAttribute(typeof(CameraProvider).Assembly, typeof(GuidAttribute))).Value);
 
         [ImportingConstructor]
         public CameraProvider(IProfileService profileService, IExposureDataFactory exposureDataFactory) {
             this.profileService = profileService;
             this.exposureDataFactory = exposureDataFactory;
-            this.pluginSettings = new PluginOptionsAccessor(profileService, PluginGuid);
+            this.pluginSettings = new PluginOptionsAccessor(profileService, SonyCamera.PluginGuid);
 
             if (!DllLoader.IsX86()) {
                 try {

--- a/Drivers/CameraProvider.cs
+++ b/Drivers/CameraProvider.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.ComponentModel.Composition;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using NINA.RetroKiwi.Plugin.SonyCamera;
 using NINA.Image.Interfaces;
 using NINA.WPF.Base.Mediator;
 using Sony;
@@ -52,7 +53,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             var devices = new List<ICamera>();
             bool enableNativeCancel = false;
             try {
-                var raw = pluginSettings.GetValueString(nameof(EnableNativeCancel), bool.FalseString);
+                var raw = pluginSettings.GetValueString(nameof(SonyCamera.EnableNativeCancel), bool.FalseString);
                 enableNativeCancel = bool.TryParse(raw, out var parsed) && parsed;
             } catch (Exception ex) {
                 Logger.Warning($"Unable to read EnableNativeCancel setting; defaulting to false. {ex.Message}");

--- a/Drivers/CameraProvider.cs
+++ b/Drivers/CameraProvider.cs
@@ -47,21 +47,13 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public IList<ICamera> GetEquipment() {
             var devices = new List<ICamera>();
-            bool enableNativeCancel = false;
-            try {
-                var raw = pluginSettings.GetValueString(nameof(SonyCamera.EnableNativeCancel), bool.FalseString);
-                enableNativeCancel = bool.TryParse(raw, out var parsed) && parsed;
-            } catch (Exception ex) {
-                Logger.Warning($"Unable to read EnableNativeCancel setting; defaulting to false. {ex.Message}");
-            }
-
             if (this.driver != null) {
                 try {
                     int count = 0;
 
                     foreach (var sonyDevice in driver.Cameras()) {
                         count++;
-                        devices.Add(new CameraDriver(profileService, exposureDataFactory, sonyDevice, enableNativeCancel));
+                        devices.Add(new CameraDriver(profileService, exposureDataFactory, sonyDevice, pluginSettings, false));
                     }
 
                     Logger.Info($"Found {count} Sony Cameras");

--- a/Drivers/CameraProvider.cs
+++ b/Drivers/CameraProvider.cs
@@ -52,7 +52,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
             var devices = new List<ICamera>();
             bool enableNativeCancel = false;
             try {
-                var raw = pluginSettings.GetValueString("EnableNativeCancel", bool.FalseString);
+                var raw = pluginSettings.GetValueString(nameof(EnableNativeCancel), bool.FalseString);
                 enableNativeCancel = bool.TryParse(raw, out var parsed) && parsed;
             } catch (Exception ex) {
                 Logger.Warning($"Unable to read EnableNativeCancel setting; defaulting to false. {ex.Message}");

--- a/Drivers/CameraProvider.cs
+++ b/Drivers/CameraProvider.cs
@@ -2,6 +2,7 @@
 using NINA.Equipment.Interfaces.ViewModel;
 using NINA.Equipment.Interfaces;
 using NINA.Profile.Interfaces;
+using NINA.Profile;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,6 +10,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.ComponentModel.Composition;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using NINA.Image.Interfaces;
 using NINA.WPF.Base.Mediator;
 using Sony;
@@ -24,11 +27,15 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
         private IProfileService profileService;
         private IExposureDataFactory exposureDataFactory;
         SonyDriver driver;
+        private readonly PluginOptionsAccessor pluginSettings;
+        private static readonly Guid PluginGuid =
+            Guid.Parse(((GuidAttribute)Attribute.GetCustomAttribute(typeof(CameraProvider).Assembly, typeof(GuidAttribute))).Value);
 
         [ImportingConstructor]
         public CameraProvider(IProfileService profileService, IExposureDataFactory exposureDataFactory) {
             this.profileService = profileService;
             this.exposureDataFactory = exposureDataFactory;
+            this.pluginSettings = new PluginOptionsAccessor(profileService, PluginGuid);
 
             if (!DllLoader.IsX86()) {
                 try {
@@ -43,6 +50,13 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
         public IList<ICamera> GetEquipment() {
             var devices = new List<ICamera>();
+            bool enableNativeCancel = false;
+            try {
+                var raw = pluginSettings.GetValueString("EnableNativeCancel", bool.FalseString);
+                enableNativeCancel = bool.TryParse(raw, out var parsed) && parsed;
+            } catch (Exception ex) {
+                Logger.Warning($"Unable to read EnableNativeCancel setting; defaulting to false. {ex.Message}");
+            }
 
             if (this.driver != null) {
                 try {
@@ -50,7 +64,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera.Drivers {
 
                     foreach (var sonyDevice in driver.Cameras()) {
                         count++;
-                        devices.Add(new CameraDriver(profileService, exposureDataFactory, sonyDevice));
+                        devices.Add(new CameraDriver(profileService, exposureDataFactory, sonyDevice, enableNativeCancel));
                     }
 
                     Logger.Info($"Found {count} Sony Cameras");

--- a/Options.xaml
+++ b/Options.xaml
@@ -7,7 +7,10 @@
     <!--  Furthermore the Resource Dictionary has to be exported via code behind export attributes  -->
     <DataTemplate x:Key="Sony Camera Plugin_Options">
         <StackPanel Orientation="Vertical" Margin="0,4,0,0">
-            <CheckBox Content="Enable native cancel (may crash on some bodies)"
+            <TextBlock Text="Capture cancellation" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,4" />
+            <TextBlock Text="Use the camera's native CancelCapture call during aborts. Disable if you see crashes on abort; enable if you need to force-stop exposures." TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
+            <CheckBox Content="Enable native cancel"
+                      HorizontalAlignment="Left"
                       IsChecked="{Binding EnableNativeCancel, Mode=TwoWay}"
                       ToolTip="When enabled, the driver will call the camera's native CancelCapture. On some bodies this can cause VCRUNTIME crashes." />
         </StackPanel>

--- a/Options.xaml
+++ b/Options.xaml
@@ -8,11 +8,10 @@
     <DataTemplate x:Key="Sony Camera Plugin_Options">
         <StackPanel Orientation="Vertical" Margin="0,4,0,0">
             <TextBlock Text="Camera native capture cancellation" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,4" />
-            <TextBlock Text="Use the camera's native CancelCapture call during aborts. Disable if you see crashes on abort; enable if you need to force-stop exposures." TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
+            <TextBlock Text="Use the camera's native CancelCapture call during aborts. Stability varies by camera model and Windows driver stack and can cause VCRUNTIME crashes. Disable if aborts crash NINA; enable if you need to force-stop exposures." TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
             <CheckBox Content="Enable native cancel"
                       HorizontalAlignment="Left"
-                      IsChecked="{Binding EnableNativeCancel, Mode=TwoWay}"
-                      ToolTip="When enabled, the driver will call the camera's native CancelCapture. Native CancelCapture stability varies by camera model and Windows driver stack. It can cause VCRUNTIME crashes. Disable if aborts cause Nina crashes." />
+                      IsChecked="{Binding EnableNativeCancel, Mode=TwoWay}" />
         </StackPanel>
     </DataTemplate>
 </ResourceDictionary>

--- a/Options.xaml
+++ b/Options.xaml
@@ -6,15 +6,10 @@
     <!--  In order for this datatemplate to be picked correctly, the key has to follow the naming convention of <IPlugin.Name>_Options -->
     <!--  Furthermore the Resource Dictionary has to be exported via code behind export attributes  -->
     <DataTemplate x:Key="Sony Camera Plugin_Options">
-        <!--        <StackPanel Orientation="Vertical"> -->
-    <!--            <StackPanel Orientation="Horizontal"> -->
-    <!--                <TextBlock Text="Default Notification Message" /> -->
-    <!--                <TextBox MinWidth="50" Text="{Binding DefaultNotificationMessage}" /> -->
-    <!--            </StackPanel> -->
-    <!--            <StackPanel Orientation="Horizontal"> -->
-    <!--                <TextBlock Text="Profile Specific Notification Message" /> -->
-    <!--                <TextBox MinWidth="50" Text="{Binding ProfileSpecificNotificationMessage}" /> -->
-    <!--            </StackPanel> -->
-    <!--        </StackPanel> -->
+        <StackPanel Orientation="Vertical" Margin="0,4,0,0">
+            <CheckBox Content="Enable native cancel (may crash on some bodies)"
+                      IsChecked="{Binding EnableNativeCancel, Mode=TwoWay}"
+                      ToolTip="When enabled, the driver will call the camera's native CancelCapture. On some bodies this can cause VCRUNTIME crashes." />
+        </StackPanel>
     </DataTemplate>
 </ResourceDictionary>

--- a/Options.xaml
+++ b/Options.xaml
@@ -12,7 +12,7 @@
             <CheckBox Content="Enable native cancel"
                       HorizontalAlignment="Left"
                       IsChecked="{Binding EnableNativeCancel, Mode=TwoWay}"
-                      ToolTip="When enabled, the driver will call the camera's native CancelCapture. On some bodies this can cause VCRUNTIME crashes." />
+                      ToolTip="When enabled, the driver will call the camera's native CancelCapture. Native CancelCapture stability varies by camera model and Windows driver stack. It can cause VCRUNTIME crashes. Disable if aborts cause Nina crashes." />
         </StackPanel>
     </DataTemplate>
 </ResourceDictionary>

--- a/Options.xaml
+++ b/Options.xaml
@@ -7,7 +7,7 @@
     <!--  Furthermore the Resource Dictionary has to be exported via code behind export attributes  -->
     <DataTemplate x:Key="Sony Camera Plugin_Options">
         <StackPanel Orientation="Vertical" Margin="0,4,0,0">
-            <TextBlock Text="Capture cancellation" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,4" />
+            <TextBlock Text="Camera native capture cancellation" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,4" />
             <TextBlock Text="Use the camera's native CancelCapture call during aborts. Disable if you see crashes on abort; enable if you need to force-stop exposures." TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
             <CheckBox Content="Enable native cancel"
                       HorizontalAlignment="Left"

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("1.0.0.4")]
-[assembly: AssemblyFileVersion("1.0.0.4")]
+[assembly: AssemblyVersion("1.0.0.5")]
+[assembly: AssemblyFileVersion("1.0.0.5")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Sony Camera Plugin")]
@@ -33,6 +33,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyMetadata("LicenseURL", "https://www.mozilla.org/en-US/MPL/2.0/")]
 // The repository where your pluggin is hosted
 [assembly: AssemblyMetadata("Repository", "https://github.com/dougforpres/NINASonyCameraPlugin")]
+// Note on native cancel: stability depends on camera model and Windows driver stack; leave disabled if aborts crash.
+[assembly: AssemblyMetadata("NativeCancelHint", "Native CancelCapture stability varies by camera model and Windows driver stack; disable if aborts crash.")]
 
 // The following attributes are optional for the official manifest meta data
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -33,8 +33,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyMetadata("LicenseURL", "https://www.mozilla.org/en-US/MPL/2.0/")]
 // The repository where your pluggin is hosted
 [assembly: AssemblyMetadata("Repository", "https://github.com/dougforpres/NINASonyCameraPlugin")]
-// Note on native cancel: stability depends on camera model and Windows driver stack; leave disabled if aborts crash.
-[assembly: AssemblyMetadata("NativeCancelHint", "Native CancelCapture stability varies by camera model and Windows driver stack; disable if aborts crash.")]
 
 // The following attributes are optional for the official manifest meta data
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ https://github.com/dougforpres/NINASonyCameraPlugin/releases
 - Binning and sub-sampling are not supported; captures use the full sensor frame.
 - For exposures <= 30s the driver chooses the nearest built-in shutter speed; longer exposures fall back to Bulb.
 - Powering off/unplugging the camera while connected can crash NINA via Windows' MTP stack (PortableDeviceApi.dll access violation); disconnect in NINA first to avoid it.
+- The “Enable native cancel” option calls the camera’s CancelCapture; stability varies by body and Windows driver stack. Leave it off if you see crashes when aborting exposures.
 
 ## Support
 
@@ -43,7 +44,7 @@ https://github.com/dougforpres/NINASonyCameraPlugin/releases
 
 ## Metadata
 
-- Version: 1.0.0.4
+- Version: 1.0.0.5
 - Author: Doug Henderson
 - Contributors: Lucas Lepski [@ShurkanTwo](https://github.com/shurkanTwo)
 - Minimum NINA version: 3.2.0.3001

--- a/SonyCameraPlugin.cs
+++ b/SonyCameraPlugin.cs
@@ -72,6 +72,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera {
         private void ProfileService_ProfileChanged(object sender, EventArgs e) {
             // Rase the event that this profile specific value has been changed due to the profile switch
             RaisePropertyChanged(nameof(ProfileSpecificNotificationMessage));
+            RaisePropertyChanged(nameof(EnableNativeCancel));
         }
 
         private Task ImageSaveMediator_BeforeImageSaved(object sender, BeforeImageSavedEventArgs e) {
@@ -128,6 +129,17 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera {
             }
             set {
                 pluginSettings.SetValueString(nameof(ProfileSpecificNotificationMessage), value);
+                RaisePropertyChanged();
+            }
+        }
+
+        public bool EnableNativeCancel {
+            get {
+                var raw = pluginSettings.GetValueString(nameof(EnableNativeCancel), bool.FalseString);
+                return bool.TryParse(raw, out var enabled) && enabled;
+            }
+            set {
+                pluginSettings.SetValueString(nameof(EnableNativeCancel), value.ToString());
                 RaisePropertyChanged();
             }
         }

--- a/SonyCameraPlugin.cs
+++ b/SonyCameraPlugin.cs
@@ -28,6 +28,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera {
     /// </summary>
     [Export(typeof(IPluginManifest))]
     public class SonyCamera : PluginBase, INotifyPropertyChanged {
+        public static readonly Guid PluginGuid = Guid.Parse("f3fd7bb5-2b69-40cc-846f-4f4a2ff62518");
         private readonly IPluginOptionsAccessor pluginSettings;
         private readonly IProfileService profileService;
         private readonly IImageSaveMediator imageSaveMediator;
@@ -44,7 +45,7 @@ namespace NINA.RetroKiwi.Plugin.SonyCamera {
             }
 
             // This helper class can be used to store plugin settings that are dependent on the current profile
-            this.pluginSettings = new PluginOptionsAccessor(profileService, Guid.Parse(this.Identifier));
+            this.pluginSettings = new PluginOptionsAccessor(profileService, PluginGuid);
             this.profileService = profileService;
             // React on a changed profile
             profileService.ProfileChanged += ProfileService_ProfileChanged;


### PR DESCRIPTION
Summary of changes:

- Add plugin setting for “Enable native cancel”, expose it via Options.xaml, and persist via shared PluginGuid accessors.
- Serialize capture operations with a lock, add status helpers/guardrails, and block new starts when the camera reports busy or unknown states.
- Use native CancelCapture when enabled; otherwise record a soft cancel and surface warnings instead of crashing. --> cancels loops after current capture is done.
- Tolerate status read failures
- bump metadata/docs to version 1.0.0.5.

This fixes or at least improves #4 

<img width="2772" height="342" alt="image" src="https://github.com/user-attachments/assets/6d1d543e-0462-430a-a64f-de509413834c" />
